### PR TITLE
Stats export + run totals + Discord totals (NDJSON)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,4 @@ marimo/_lsp/
 __marimo__/
 
 chonk_backlog_issues.csv
+*.csv

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,10 @@ x-common-env: &common-env
   PREVIEW: "false"
   FAIL_FAST: "true"
 
+  # ---- Stats / Reporting ----
+  STATS_ENABLED: "true"          # enable NDJSON stats export
+  APP_VERSION: "v1.1.0"          # version stamp written into stats entries
+
   # ---- Retries ----
   RETRY_COUNT: "1"
   RETRY_BACKOFF_SECS: "5"
@@ -77,9 +81,10 @@ services:
       # ---- Roots ----
       MEDIA_ROOT: /movies
       WORK_ROOT: /work
+      STATS_PATH: /movies/.chonkstats.ndjson
 
       # ---- Movie-specific selection ----
-      MIN_SIZE_GB: "20"
+      MIN_SIZE_GB: "17"
 
     volumes:
       - /volume1/movies:/movies:rw
@@ -111,7 +116,8 @@ services:
       # ---- Roots ----
       MEDIA_ROOT: /tv_shows
       WORK_ROOT: /work
-
+      STATS_PATH: /tv_shows/.chonkstats.ndjson
+      
       # ---- TV-specific selection ----
       MIN_SIZE_GB: "8"
 

--- a/scripts/chonkreducer_task.sh
+++ b/scripts/chonkreducer_task.sh
@@ -73,7 +73,7 @@ send_discord() {
   DISCORD_DEBUG="${DISCORD_DEBUG:-false}"
 
   # Keep the payload short and safe (Discord message limits + JSON escaping)
-  SUMMARY="$(grep -E 'RUN_ID=|MODE=|Processed:|Failed:|TOTAL SAVED:|Saved:|TOTAL RATE:|Run log:' "$WRAPPER_LOG" 2>/dev/null | tail -n 25)"
+  SUMMARY="$(grep -E 'RUN_ID=|MODE=|Processed:|Failed:|TOTAL BEFORE \(run\):|TOTAL AFTER \(run\):|TOTAL SAVED \(run\):|TOTAL SAVED PCT \(run\):|RUN DURATION:|TOTAL TIME:|TOTAL RATE:|Run log:' "$WRAPPER_LOG" 2>/dev/null | tail -n 40)"
 
   # Fallback: last lines of wrapper log
   if [ -z "$SUMMARY" ]; then

--- a/src/chonk_reducer/config.py
+++ b/src/chonk_reducer/config.py
@@ -90,12 +90,23 @@ class Config:
     retry_backoff_secs: int
     preview: bool
 
+    stats_enabled: bool
+    stats_path: Path
+    library: str
+    version: str
+    encoder: str
+
 def load_config() -> Config:
     excl = _split_csv(_env("EXCLUDE_PATH_PARTS", "#recycle,@eaDir"))
-    
+
+    media_root = Path(_env("MEDIA_ROOT", "/movies"))
+    work_root = Path(_env("WORK_ROOT", "/work"))
+    default_library = "tv" if "tv" in str(media_root).lower() else "movie"
+    stats_path = Path(_env("STATS_PATH", str(media_root / ".chonkstats.ndjson")))
+
     return Config(
-        media_root=Path(_env("MEDIA_ROOT", "/movies")),
-        work_root=Path(_env("WORK_ROOT", "/work")),
+        media_root=media_root,
+        work_root=work_root,
 
         min_size_gb=_env_float("MIN_SIZE_GB", 18.0),
         max_files=_env_int("MAX_FILES", 2),
@@ -134,4 +145,11 @@ def load_config() -> Config:
         retry_count=_env_int("RETRY_COUNT", 1),
         retry_backoff_secs=_env_int("RETRY_BACKOFF_SECS", 5),
         preview=_env_bool("PREVIEW", False),
+
+        # Stats / reporting
+        stats_enabled=_env_bool("STATS_ENABLED", False),
+        stats_path=stats_path,
+        library=_env("LIBRARY", default_library),
+        version=_env("APP_VERSION", "dev"),
+        encoder=_env("ENCODER", "hevc_qsv"),
     )

--- a/src/chonk_reducer/runner.py
+++ b/src/chonk_reducer/runner.py
@@ -14,6 +14,8 @@ from .logging_utils import Logger, make_run_stamp
 from .swap import swap_in
 from .validation import validate_post_encode
 from .ffmpeg_utils import probe_video_stream
+from .stats import record_success, record_failure, record_dry_run
+from . import __version__ as PKG_VERSION
 
 
 def _fmt_hms(seconds: float) -> str:
@@ -66,6 +68,8 @@ def run() -> int:
     stamp = make_run_stamp()
     run_id = uuid.uuid4().hex[:8]
 
+    run_start = time.monotonic()
+
     log_dir = cfg.work_root / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
 
@@ -82,6 +86,9 @@ def run() -> int:
     if cfg.dry_run:
         mode = "DRY_RUN"
     logger.log(f"RUN_ID={run_id} MODE={mode}")
+    logger.log(f"VERSION={PKG_VERSION}")
+    logger.log(f"STATS_ENABLED={getattr(cfg, 'stats_enabled', False)}")
+    logger.log(f"STATS_PATH={getattr(cfg, 'stats_path', '')}")
     logger.log(f"MEDIA_ROOT={cfg.media_root}")
     logger.log(f"WORK_ROOT={cfg.work_root}")
     logger.log(f"MIN_SIZE_GB={cfg.min_size_gb} MAX_FILES={cfg.max_files}")
@@ -105,6 +112,8 @@ def run() -> int:
     logger.log(f"Run log: {run_log}")
 
     if not _validate_config(cfg, logger):
+        run_duration = time.monotonic() - run_start
+        logger.log(f"RUN DURATION: {_fmt_hms(run_duration)}")
         logger.log("===== END =====")
         return 1
 
@@ -121,6 +130,8 @@ def run() -> int:
             if reason:
                 logger.log(f"PAUSE reason: {reason}")
         logger.log(f"PAUSE detected at {pause_file} — exiting without processing.")
+        run_duration = time.monotonic() - run_start
+        logger.log(f"RUN DURATION: {_fmt_hms(run_duration)}")
         logger.log("===== END =====")
         return 0
 
@@ -209,10 +220,14 @@ def run() -> int:
                     )
                 else:
                     logger.log(f"DRY_RUN: would encode + swap: {src}")
+
+                # Optional stats entry for dry run
+                record_dry_run(cfg, logger, run_id, src, before_bytes)
+
                 processed += 1
                 done += 1
                 break
-                continue
+
 
             stamp2 = make_run_stamp()
             encoded = src.parent / f"{src.name}.{stamp2}.encoded.mkv"
@@ -238,8 +253,10 @@ def run() -> int:
 
                 t0 = time.monotonic()
                 try:
+                    stage = "encode"
                     encode_qsv(src, encoded, cfg, logger)
 
+                    stage = "validate"
                     if not validate_post_encode(encoded, cfg, logger):
                         raise RuntimeError("Post-encode validation failed")
 
@@ -265,7 +282,8 @@ def run() -> int:
                             done += 1
                             continue
 
-                    swap_in(src, encoded, cfg, logger)
+                    stage = "swap"
+                    bak_path, marker_path = swap_in(src, encoded, cfg, logger)
 
                     after_probe = None
                     try:
@@ -336,6 +354,21 @@ def run() -> int:
                         logger.log(f"METRICS: elapsed={_fmt_hms(elapsed)}")
 
                     logger.log(f"OK: swapped + marked: {src}")
+                    # Stats (success) - append after marker write
+                    record_success(
+                        cfg,
+                        logger,
+                        run_id=run_id,
+                        mode=mode.lower(),
+                        stage="swap",
+                        src=src,
+                        before_bytes=int(before_bytes or 0),
+                        after_bytes=int(after_bytes or 0),
+                        codec_from=(before_probe.get("codec") if before_probe else None),
+                        codec_to=(after_probe.get("codec") if after_probe else None),
+                        duration_seconds=float(elapsed),
+                        bak_path=bak_path,
+                    )
                     processed += 1
                     done += 1
                     break
@@ -354,6 +387,19 @@ def run() -> int:
                     if attempt < cfg.retry_count:
                         continue
 
+                    # Final failure: record stats + mark file as failed/quarantined
+                    record_failure(
+                        cfg,
+                        logger,
+                        run_id=run_id,
+                        mode=mode.lower(),
+                        stage=stage if "stage" in locals() else "unknown",
+                        src=src,
+                        before_bytes=int(before_bytes or 0),
+                        duration_seconds=float(time.monotonic() - t0),
+                        err=e,
+                        encoded_path=encoded,
+                    )
                     # Final failure: mark file as failed/quarantined
                     failed += 1
                     fail_marker = src.with_suffix(src.suffix + ".failed")
@@ -394,11 +440,10 @@ def run() -> int:
         if bytes_before_total:
             saved_total = bytes_before_total - bytes_after_total
             pct_total = (saved_total / bytes_before_total) * 100.0 if bytes_before_total > 0 else 0.0
-            logger.log(
-                f"TOTAL SAVINGS: before={bytes_before_total/1024**3:.2f}GB "
-                f"after={bytes_after_total/1024**3:.2f}GB "
-                f"saved={saved_total/1024**3:.2f}GB ({pct_total:.1f}%)"
-            )
+            logger.log(f"TOTAL BEFORE (run):    {bytes_before_total/1024**3:.2f}GB")
+            logger.log(f"TOTAL AFTER (run):     {bytes_after_total/1024**3:.2f}GB")
+            logger.log(f"TOTAL SAVED (run):     {saved_total/1024**3:.2f}GB")
+            logger.log(f"TOTAL SAVED PCT (run): {pct_total:.1f}%")
 
         if elapsed_total:
             logger.log(f"TOTAL TIME: {_fmt_hms(elapsed_total)}")
@@ -418,6 +463,8 @@ def run() -> int:
                 )
             logger.log("============================")
 
+        run_duration = time.monotonic() - run_start
+        logger.log(f"RUN DURATION: {_fmt_hms(run_duration)}")
         logger.log("===== END =====")
         return 0 if failed == 0 else 2
 

--- a/src/chonk_reducer/stats.py
+++ b/src/chonk_reducer/stats.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from .config import Config
+from .logging_utils import Logger
+
+
+def _iso_ts() -> str:
+    # ISO-8601 without timezone (consistent with existing logs)
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime())
+
+
+def _safe_str(e: Exception) -> str:
+    s = str(e).replace("\n", " ").strip()
+    # keep it compact for Discord/logging/import
+    return (s[:500] + "…") if len(s) > 500 else s
+
+
+def append_ndjson(path: Path, obj: dict[str, Any], logger: Logger) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(obj, ensure_ascii=False, separators=(",", ":"))
+        with path.open("a", encoding="utf-8", newline="\n") as f:
+            f.write(line + "\n")
+    except Exception as e:
+        logger.log(f"WARN: stats append failed: {path} ({e})")
+
+
+def infer_library(cfg: Config) -> str:
+    if getattr(cfg, "library", ""):
+        return cfg.library
+    s = str(cfg.media_root).lower()
+    if "tv" in s:
+        return "tv"
+    if "movie" in s:
+        return "movie"
+    return "media"
+
+
+def build_base(cfg: Config, run_id: str, mode: str) -> dict[str, Any]:
+    return {
+        "ts": _iso_ts(),
+        "run_id": run_id,
+        "version": getattr(cfg, "version", "") or "unknown",
+        "library": infer_library(cfg),
+        "mode": mode,
+        "encoder": getattr(cfg, "encoder", "hevc_qsv"),
+        "quality": int(cfg.qsv_quality),
+        "preset": int(cfg.qsv_preset),
+    }
+
+
+def record_success(
+    cfg: Config,
+    logger: Logger,
+    run_id: str,
+    mode: str,
+    stage: str,
+    src: Path,
+    before_bytes: int,
+    after_bytes: int,
+    codec_from: str | None,
+    codec_to: str | None,
+    duration_seconds: float,
+    bak_path: Path | None = None,
+) -> None:
+    if not getattr(cfg, "stats_enabled", False):
+        return
+    saved = int(before_bytes) - int(after_bytes)
+    pct = (saved / before_bytes) * 100.0 if before_bytes else 0.0
+
+    obj = build_base(cfg, run_id, mode)
+    obj.update(
+        {
+            "status": "success",
+            "stage": stage,
+            "path": str(src),
+            "filename": src.name,
+            "size_before_bytes": int(before_bytes),
+            "size_after_bytes": int(after_bytes),
+            "saved_bytes": int(saved),
+            "saved_pct": round(pct, 3),
+            "codec_from": codec_from or "",
+            "codec_to": codec_to or "",
+            "duration_seconds": round(float(duration_seconds), 3),
+        }
+    )
+    if bak_path is not None:
+        obj["bak_path"] = str(bak_path)
+
+    append_ndjson(Path(cfg.stats_path), obj, logger)
+
+
+def record_failure(
+    cfg: Config,
+    logger: Logger,
+    run_id: str,
+    mode: str,
+    stage: str,
+    src: Path,
+    before_bytes: int,
+    duration_seconds: float,
+    err: Exception,
+    encoded_path: Path | None = None,
+) -> None:
+    if not getattr(cfg, "stats_enabled", False):
+        return
+
+    obj = build_base(cfg, run_id, mode)
+    obj.update(
+        {
+            "status": "failed",
+            "stage": stage,
+            "path": str(src),
+            "filename": src.name,
+            "size_before_bytes": int(before_bytes),
+            "duration_seconds": round(float(duration_seconds), 3),
+            "error_type": type(err).__name__,
+            "error_msg": _safe_str(err),
+        }
+    )
+
+    if encoded_path is not None:
+        obj["encoded_path"] = str(encoded_path)
+        try:
+            obj["encoded_bytes"] = int(encoded_path.stat().st_size)
+        except Exception:
+            pass
+
+    append_ndjson(Path(cfg.stats_path), obj, logger)
+
+
+def record_dry_run(
+    cfg: Config,
+    logger: Logger,
+    run_id: str,
+    src: Path,
+    before_bytes: int,
+) -> None:
+    if not getattr(cfg, "stats_enabled", False):
+        return
+    obj = build_base(cfg, run_id, "dry_run")
+    obj.update(
+        {
+            "status": "skipped",
+            "stage": "dry_run",
+            "path": str(src),
+            "filename": src.name,
+            "size_before_bytes": int(before_bytes),
+        }
+    )
+    append_ndjson(Path(cfg.stats_path), obj, logger)


### PR DESCRIPTION
Adds per-library NDJSON stats export (.chonkstats.ndjson) with success + failure records
Adds run-level totals (before/after/saved/pct/time/rate) to logs
Updates Discord wrapper summary to include run totals
Adds .gitattributes to enforce LF line endings across sh/yaml/py/Dockerfile/env

Closes #14