### PR TITLE
updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ Chonk Reducer is a **policy-driven media size reduction system** built for NAS e
 - Quarantines repeated failures with `.failed` marker
 - Logs metrics and per-show rollups
 
+### Run Summary Counters
+
+At the end of each run, the runner prints stage-oriented counters:
+
+- `Candidates found`
+- `Pre-filtered` (marker/backup)
+- `Evaluated`
+- `Processed (encode)`
+- `Succeeded`
+- `Skipped (policy)`
+- `Failed`
+
+
 ---
 
 ## High-Level Architecture
@@ -408,6 +421,8 @@ Keep TV and Movie containers in the **same order** for consistency.
 
 Each processed file appends a single JSON line to:
 
+Version stamping uses `APP_VERSION` if set; otherwise it falls back to the package `__version__` (or `unknown`).
+
 - `/tv_shows/.chonkstats.ndjson`
 - `/movies/.chonkstats.ndjson`
 
@@ -423,6 +438,8 @@ Each processed file appends a single JSON line to:
 - `preset`
 - `status`
 - `stage`
+- `skip_reason` (when `status=skipped`)
+- `fail_stage` (when `status=failed`)
 - `path`
 - `filename`
 - `size_before_bytes`
@@ -433,6 +450,13 @@ Each processed file appends a single JSON line to:
 - `codec_to`
 - `duration_seconds`
 - `bak_path`
+
+### Status Semantics
+
+- `status` is one of: `success`, `skipped`, `failed`
+- If `status=skipped`, `skip_reason` is recorded (e.g., `codec`, `resolution`, `min_savings`, `dry_run`)
+- If `status=failed`, `fail_stage` is recorded (e.g., `probe`, `encode`, `validate`, `swap`)
+- Older NDJSON rows may not include `skip_reason`/`fail_stage`; reports treat these as `unknown`.
 
 This file is append-only and intended as the source of truth for reporting and aggregation (e.g., weekly reports).
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ x-common-env: &common-env
 
   # ---- Stats / Reporting ----
   STATS_ENABLED: "true"          # enable NDJSON stats export
-  APP_VERSION: "v1.3.0"          # version stamp written into stats entries
+  APP_VERSION: "v1.4.0"          # version stamp written into stats entries
   REPORTS_DIR: "/work/reports"
   WEEKLY_REPORT_DAYS: "7"
   WEEKLY_STATS_PATHS: "/tv_shows/.chonkstats.ndjson,/movies/.chonkstats.ndjson"

--- a/src/chonk_reducer/config.py
+++ b/src/chonk_reducer/config.py
@@ -130,7 +130,7 @@ def load_config() -> Config:
     stats_path = Path(_env("STATS_PATH", str(default_stats_path)))
     library = _env("LIBRARY", "")
     encoder = _env("ENCODER", "hevc_qsv")
-    app_version = os.getenv("APP_VERSION") or os.getenv("VERSION") or PACKAGE_VERSION
+    app_version = (os.getenv("APP_VERSION") or "").strip() or (PACKAGE_VERSION or "").strip() or "unknown"
 
     return Config(
         version=app_version,

--- a/src/chonk_reducer/runner.py
+++ b/src/chonk_reducer/runner.py
@@ -15,7 +15,7 @@ from .swap import swap_in
 from .validation import validate_post_encode
 from .ffmpeg_utils import probe_video_stream
 from .skip_policy import evaluate_skip
-from .stats import record_success, record_failure, record_dry_run
+from .stats import record_success, record_failure, record_dry_run, record_skip
 from . import __version__ as PKG_VERSION
 
 
@@ -87,7 +87,7 @@ def run() -> int:
     if cfg.dry_run:
         mode = "DRY_RUN"
     logger.log(f"RUN_ID={run_id} MODE={mode}")
-    logger.log(f"VERSION={PKG_VERSION}")
+    logger.log(f"VERSION={cfg.version}")
     logger.log(f"STATS_ENABLED={getattr(cfg, 'stats_enabled', False)}")
     logger.log(f"STATS_PATH={getattr(cfg, 'stats_path', '')}")
     logger.log(f"MEDIA_ROOT={cfg.media_root}")
@@ -144,14 +144,16 @@ def run() -> int:
         return 0
 
     done = 0
-    processed = 0
+    evaluated = 0
+    processed = 0  # files where an encode attempt occurred
+    succeeded = 0
     failed = 0
-    considered = 0
     skipped_marker = 0
     skipped_backup = 0
     skipped_min_savings = 0
     skipped_codec = 0
     skipped_resolution = 0
+    skipped_dry_run = 0
 
     bytes_before_total = 0
     bytes_after_total = 0
@@ -209,7 +211,7 @@ def run() -> int:
                     logger.log(f"SKIP(backup): {src}")
                 continue
 
-            considered += 1
+            evaluated += 1
             logger.log(f"Processing: {src}")
 
             try:
@@ -230,7 +232,7 @@ def run() -> int:
                 # Optional stats entry for dry run
                 record_dry_run(cfg, logger, run_id, src, before_bytes)
 
-                processed += 1
+                skipped_dry_run += 1
                 done += 1
                 break
 
@@ -260,9 +262,22 @@ def run() -> int:
                     skipped_resolution += 1
                 if cfg.log_skips:
                     logger.log(f"SKIP({cat}): {reason} :: {src}")
+                # Stats: record policy/runtime skips (avoid marker/backup prefilters)
+                record_skip(
+                    cfg,
+                    logger,
+                    run_id=run_id,
+                    mode=mode.lower(),
+                    skip_reason=cat,
+                    src=src,
+                    before_bytes=int(before_bytes or 0),
+                    codec_from=(before_probe.get('codec') if before_probe else None),
+                    detail=str(reason),
+                )
                 continue
 
             attempt_errors: list[str] = []
+            encode_attempted = False
             for attempt in range(cfg.retry_count + 1):
                 if attempt > 0:
                     logger.log(f"RETRY {attempt}/{cfg.retry_count}: {src}")
@@ -272,6 +287,9 @@ def run() -> int:
                 t0 = time.monotonic()
                 try:
                     stage = "encode"
+                    if not encode_attempted:
+                        processed += 1
+                        encode_attempted = True
                     encode_qsv(src, encoded, cfg, logger)
 
                     stage = "validate"
@@ -296,6 +314,17 @@ def run() -> int:
                             except Exception:
                                 pass
                             skipped_min_savings += 1
+                            record_skip(
+                                cfg,
+                                logger,
+                                run_id=run_id,
+                                mode=mode.lower(),
+                                skip_reason='min_savings',
+                                src=src,
+                                before_bytes=int(before_bytes or 0),
+                                codec_from=(before_probe.get('codec') if before_probe else None),
+                                detail=f"{pct_tmp:.1f}% < {cfg.min_savings_percent:.1f}%",
+                            )
                             done += 1
                             break
 
@@ -386,7 +415,7 @@ def run() -> int:
                         duration_seconds=float(elapsed),
                         bak_path=bak_path,
                     )
-                    processed += 1
+                    succeeded += 1
                     done += 1
                     break
 
@@ -435,17 +464,23 @@ def run() -> int:
                     done += 1
 
         # Summary
-        logger.log("===== SUMMARY =====")
+                logger.log("===== SUMMARY =====")
         ignored_files = sum(ignored_folders.values()) if ignored_folders else 0
+        prefiltered = skipped_marker + skipped_backup
+        skipped_policy = skipped_codec + skipped_resolution + skipped_min_savings + skipped_dry_run
         logger.log(f"Candidates found:     {len(cands)}")
-        logger.log(f"Considered:           {considered}")
-        logger.log(f"Processed:            {processed}")
-        logger.log(f"Skipped (marker):     {skipped_marker}")
-        logger.log(f"Skipped (backup):     {skipped_backup}")
+        logger.log(f"Pre-filtered:         {prefiltered}")
+        logger.log(f"Evaluated:            {evaluated}")
+        logger.log(f"Processed (encode):   {processed}")
+        logger.log(f"Succeeded:            {succeeded}")
+        logger.log(f"Skipped (policy):     {skipped_policy}")
+        logger.log(f"Failed:               {failed}")
+        logger.log(f"Pre-filtered (marker):     {skipped_marker}")
+        logger.log(f"Pre-filtered (backup):     {skipped_backup}")
         logger.log(f"Skipped (codec):      {skipped_codec}")
         logger.log(f"Skipped (resolution): {skipped_resolution}")
         logger.log(f"Skipped (min savings): {skipped_min_savings}")
-        logger.log(f"Failed:               {failed}")
+        logger.log(f"Skipped (dry run):    {skipped_dry_run}")
         logger.log(f"Ignored folders:      {len(ignored_folders)}")
         logger.log(f"Ignored files:        {ignored_files}")
 

--- a/src/chonk_reducer/stats.py
+++ b/src/chonk_reducer/stats.py
@@ -113,8 +113,9 @@ def record_failure(
     obj = build_base(cfg, run_id, mode)
     obj.update(
         {
-            "status": "failed",
+            "status":"failed",
             "stage": stage,
+            "fail_stage": stage,
             "path": str(src),
             "filename": src.name,
             "size_before_bytes": int(before_bytes),
@@ -134,6 +135,42 @@ def record_failure(
     append_ndjson(Path(cfg.stats_path), obj, logger)
 
 
+def record_skip(
+    cfg: Config,
+    logger: Logger,
+    run_id: str,
+    mode: str,
+    skip_reason: str,
+    src: Path,
+    before_bytes: int,
+    codec_from: str | None = None,
+    detail: str | None = None,
+) -> None:
+    """Record a skipped file in NDJSON stats (policy/runtime skip, not pre-filter markers).
+
+    Note: We intentionally do not record marker/backup pre-filters to avoid bloating stats.
+    """
+    if not getattr(cfg, "stats_enabled", False):
+        return
+
+    obj = build_base(cfg, run_id, mode)
+    obj.update(
+        {
+            "status": "skipped",
+            "stage": "skip",
+            "skip_reason": (skip_reason or "unknown").lower(),
+            "path": str(src),
+            "filename": src.name,
+            "size_before_bytes": int(before_bytes),
+            "codec_from": codec_from or "",
+        }
+    )
+    if detail:
+        obj["skip_detail"] = str(detail)[:500]
+
+    append_ndjson(Path(cfg.stats_path), obj, logger)
+
+
 def record_dry_run(
     cfg: Config,
     logger: Logger,
@@ -146,8 +183,9 @@ def record_dry_run(
     obj = build_base(cfg, run_id, "dry_run")
     obj.update(
         {
-            "status": "skipped",
-            "stage": "dry_run",
+            "status":"skipped",
+            "stage":"dry_run",
+            "skip_reason":"dry_run",
             "path": str(src),
             "filename": src.name,
             "size_before_bytes": int(before_bytes),

--- a/src/chonk_reducer/weekly_report.py
+++ b/src/chonk_reducer/weekly_report.py
@@ -96,6 +96,9 @@ def generate_weekly_report() -> int:
     # Failure stage breakdown
     fail_stage: dict[str, int] = {}
 
+    # Skip reason breakdown (for status=skipped)
+    skip_reason_breakdown: dict[str, int] = {}
+
     total_rows = 0
     for sp in stats_paths:
         for row in _read_ndjson(sp):
@@ -111,7 +114,7 @@ def generate_weekly_report() -> int:
                 by_lib[lib] = Totals()
 
             status = str(row.get("status", "")).lower().strip()
-            stage = str(row.get("stage", "")).lower().strip()
+            stage = str(row.get("fail_stage") or row.get("stage") or "").lower().strip()
 
             if status == "success":
                 b = int(row.get("size_before_bytes") or 0)
@@ -140,6 +143,8 @@ def generate_weekly_report() -> int:
             elif status == "skipped":
                 for t in (by_lib[lib], combined):
                     t.skipped += 1
+                sr = str(row.get("skip_reason") or "").lower().strip() or "unknown"
+                skip_reason_breakdown[sr] = skip_reason_breakdown.get(sr, 0) + 1
             else:
                 for t in (by_lib[lib], combined):
                     t.unknown += 1
@@ -199,6 +204,13 @@ def generate_weekly_report() -> int:
     if top_saves:
         for i, r in enumerate(top_saves, start=1):
             lines.append(f"{i}) {_fmt_gb(int(r['saved_bytes']))} saved ({float(r['saved_pct']):.1f}%)  [{r['library']}]  {r['path']}")
+    else:
+        lines.append("  (none)")
+    lines.append("")
+    lines.append("Skip Breakdown (by reason):")
+    if skip_reason_breakdown:
+        for sr, cnt in sorted(skip_reason_breakdown.items(), key=lambda x: (-x[1], x[0])):
+            lines.append(f" - {sr}: {cnt}")
     else:
         lines.append("  (none)")
     lines.append("")


### PR DESCRIPTION
Closed Stories

#30 — Version Stamping Precedence

APP_VERSION now takes precedence.

Fallback to package __version__.

Removed legacy VERSION env dependency.

Verified in your log:

VERSION=v1.4.0

#31 — Summary Metrics Clarification & Reporting Refactor
New pipeline stage metrics added:

Candidates found
Pre-filtered
Evaluated
Processed (encode)
Succeeded
Skipped (policy)
Failed

Plus detailed breakdown:

Pre-filtered (marker)
Pre-filtered (backup)
Skipped (codec)
Skipped (resolution)
Skipped (min savings)
Skipped (dry run)

Your run output confirms this is working.

#32 — NDJSON Status + Reason Fields
Stats rows now include structured result info:

Example you showed:

{
 "status":"skipped",
 "stage":"skip",
 "skip_reason":"codec",
 "skip_detail":"codec=hevc"
}

This enables:

better weekly reports

easier analytics

debugging pipeline decisions

So the stories closed were:
Closed #30 Version Stamping Precedence
Closed #31 Summary Metrics Refactor
Closed #32 NDJSON Status + Reason Fields
Your issue board should now look like:

Completed

30
31
32

Remaining

33  Summary JSON output
34  Free space guard
35  Max GB per run
36  Per show savings cap
37  Failure escalation
38  Lock self healing