### PR TITLE
Stories #42, #43, #44

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Chonk Reducer is a **policy-driven media size reduction system** built for NAS e
 - Can pause instantly with `.chonkpause` (+ optional `.chonkpause.reason`)
 - Encodes **in the same folder** as the source (avoids cross-device rename errors / EXDEV)
 - Validates output (decode test)
-- Enforces **minimum savings %** before swapping
+- Enforces a **savings window** (min + optional max) before swapping
 - Backs up original with timestamped `.bak.YYYYMMDD_HHMMSS`
 - Atomic replace swap + writes `.optimized` marker
 - Retries transient failures with backoff
@@ -177,7 +177,10 @@ Yes—keep a table. It makes upgrades and troubleshooting way easier.
 | `QSV_QUALITY` | QSV quality (lower = higher quality) | `21` |
 | `QSV_PRESET` | QSV preset | `7` |
 | `EXTRA_HW_FRAMES` | QSV hw frames | `64` |
-| `MIN_SAVINGS_PERCENT` | Skip swap if savings below threshold | `15` |
+| `MIN_SAVINGS_PERCENT` | Reject encode if savings below threshold | `15` |
+| `MAX_SAVINGS_PERCENT` | Reject encode if savings above threshold (0 = disabled) | `65` |
+| `MAX_GB_PER_RUN` | Stop run after reclaiming this much space (0 = disabled) | `40` |
+| `MIN_MEDIA_FREE_GB` | Abort run if MEDIA_ROOT volume free space is below this (0 = disabled) | `50` |
 
 ### Skip Policies (Pre-Encode)
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -34,7 +34,10 @@ x-common-env: &common-env
   QSV_PRESET: "7"
   EXTRA_HW_FRAMES: "64"
   MIN_SAVINGS_PERCENT: "15"
-  
+  MIN_MEDIA_FREE_GB: "50"
+  MAX_GB_PER_RUN: "40"
+  MAX_SAVINGS_PERCENT: "65"
+
   # ---- Skip policies (pre-encode) ----
   SKIP_CODECS: "hevc,av1"          # skip if source codec matches (comma list). empty = disabled
   SKIP_MIN_HEIGHT: "2160"          # skip if height >= this. 0 = disabled

--- a/src/chonk_reducer/config.py
+++ b/src/chonk_reducer/config.py
@@ -59,6 +59,11 @@ class Config:
     # Selection
     min_size_gb: float
     max_files: int
+    min_media_free_gb: float
+    max_gb_per_run: float
+
+    # Savings policy window
+    max_savings_percent: float
 
     # Encoder
     qsv_quality: int
@@ -139,6 +144,9 @@ def load_config() -> Config:
 
         min_size_gb=_env_float("MIN_SIZE_GB", 18.0),
         max_files=_env_int("MAX_FILES", 2),
+        min_media_free_gb=_env_float("MIN_MEDIA_FREE_GB", 0.0),
+        max_gb_per_run=_env_float("MAX_GB_PER_RUN", 0.0),
+        max_savings_percent=_env_float("MAX_SAVINGS_PERCENT", 0.0),
 
         qsv_quality=_env_int("QSV_QUALITY", 21),
         qsv_preset=_env_int("QSV_PRESET", 7),

--- a/src/chonk_reducer/runner.py
+++ b/src/chonk_reducer/runner.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import sys
 import time
 import uuid
+import shutil
 
 from .cleanup import cleanup_baks, cleanup_logs, cleanup_work_dir, cleanup_media_temp
 from .config import load_config
@@ -39,6 +40,15 @@ def _validate_config(cfg, logger: Logger) -> bool:
         add("MIN_SIZE_GB must be >= 0")
     if cfg.min_savings_percent < 0 or cfg.min_savings_percent > 100:
         add("MIN_SAVINGS_PERCENT must be between 0 and 100")
+
+    if getattr(cfg, "max_savings_percent", 0) and (cfg.max_savings_percent < 0 or cfg.max_savings_percent > 100):
+        add("MAX_SAVINGS_PERCENT must be between 0 and 100")
+    if getattr(cfg, "max_savings_percent", 0) and cfg.min_savings_percent and cfg.max_savings_percent and cfg.max_savings_percent < cfg.min_savings_percent:
+        add("MAX_SAVINGS_PERCENT must be >= MIN_SAVINGS_PERCENT")
+    if getattr(cfg, "min_media_free_gb", 0) < 0:
+        add("MIN_MEDIA_FREE_GB must be >= 0")
+    if getattr(cfg, "max_gb_per_run", 0) < 0:
+        add("MAX_GB_PER_RUN must be >= 0")
     if cfg.qsv_quality <= 0 or cfg.qsv_quality > 51:
         add("QSV_QUALITY must be between 1 and 51")
     if cfg.qsv_preset <= 0 or cfg.qsv_preset > 9:
@@ -151,12 +161,14 @@ def run() -> int:
     skipped_marker = 0
     skipped_backup = 0
     skipped_min_savings = 0
+    skipped_max_savings = 0
     skipped_codec = 0
     skipped_resolution = 0
     skipped_dry_run = 0
 
     bytes_before_total = 0
     bytes_after_total = 0
+    saved_bytes_run = 0
     elapsed_total = 0.0
 
     # define for summary even if discovery fails early
@@ -172,6 +184,25 @@ def run() -> int:
         cleanup_media_temp(cfg.media_root, cfg.work_cleanup_hours, cfg.exclude_path_parts, logger)
         cleanup_logs(log_dir, cfg.log_retention_days, logger)
         cleanup_baks(cfg.media_root, cfg.bak_retention_days, logger)
+
+
+        # Free space guard (Story 42) - abort if MEDIA_ROOT volume is low on space
+        if getattr(cfg, "min_media_free_gb", 0):
+            try:
+                free_bytes = shutil.disk_usage(str(cfg.media_root)).free
+            except Exception:
+                free_bytes = 0
+            need_bytes = int(float(cfg.min_media_free_gb) * (1024 ** 3))
+            if free_bytes and free_bytes < need_bytes:
+                logger.log("===== FREE SPACE GUARD TRIGGERED =====")
+                logger.log(f"MEDIA_ROOT free space: {free_bytes/1024**3:.2f} GB")
+                logger.log(f"Required minimum: {float(cfg.min_media_free_gb):.2f} GB (MIN_MEDIA_FREE_GB)")
+                logger.log("Aborting run to protect filesystem.")
+                logger.log("====================================")
+                run_duration = time.monotonic() - run_start
+                logger.log(f"RUN DURATION: {_fmt_hms(run_duration)}")
+                logger.log("===== END =====")
+                return 2
 
         # Discovery (returns candidates + ignored folder counts)
         cands, ignored_folders = gather_candidates(cfg, logger)
@@ -196,6 +227,16 @@ def run() -> int:
         for src in cands:
             if done >= cfg.max_files:
                 break
+
+            # Max GB per run guard (Story 43)
+            if getattr(cfg, "max_gb_per_run", 0):
+                limit_bytes = float(cfg.max_gb_per_run) * (1024 ** 3)
+                if saved_bytes_run >= limit_bytes and limit_bytes > 0:
+                    logger.log(
+                        f"Max GB per run reached: saved={saved_bytes_run/1024**3:.2f}GB "
+                        f"limit={float(cfg.max_gb_per_run):.2f}GB — stopping early."
+                    )
+                    break
 
             # Skip if already optimized
             if src.with_suffix(src.suffix + ".optimized").exists():
@@ -328,6 +369,31 @@ def run() -> int:
                             done += 1
                             break
 
+                        # Max savings guard (Story 44) - reject overly aggressive reductions
+                        if getattr(cfg, 'max_savings_percent', 0) and pct_tmp > float(cfg.max_savings_percent):
+                            logger.log(
+                                f"SKIP: savings {pct_tmp:.1f}% > MAX_SAVINGS_PERCENT {float(cfg.max_savings_percent):.1f}% "
+                                f"(before={before_bytes/1024**3:.2f}GB encoded={encoded_bytes/1024**3:.2f}GB)"
+                            )
+                            try:
+                                encoded.unlink(missing_ok=True)
+                            except Exception:
+                                pass
+                            skipped_max_savings += 1
+                            record_skip(
+                                cfg,
+                                logger,
+                                run_id=run_id,
+                                mode=mode.lower(),
+                                skip_reason='max_savings',
+                                src=src,
+                                before_bytes=int(before_bytes or 0),
+                                codec_from=(before_probe.get('codec') if before_probe else None),
+                                detail=f"{pct_tmp:.1f}% > {float(cfg.max_savings_percent):.1f}%",
+                            )
+                            done += 1
+                            break
+
                     stage = "swap"
                     bak_path, marker_path = swap_in(src, encoded, cfg, logger)
 
@@ -388,6 +454,7 @@ def run() -> int:
 
                     if before_bytes and after_bytes:
                         saved = before_bytes - after_bytes
+                        saved_bytes_run += int(saved)
                         pct = (saved / before_bytes) * 100.0 if before_bytes > 0 else 0.0
                         logger.log(
                             f"METRICS: before={before_bytes/1024**3:.2f}GB "
@@ -467,7 +534,7 @@ def run() -> int:
                 logger.log("===== SUMMARY =====")
         ignored_files = sum(ignored_folders.values()) if ignored_folders else 0
         prefiltered = skipped_marker + skipped_backup
-        skipped_policy = skipped_codec + skipped_resolution + skipped_min_savings + skipped_dry_run
+        skipped_policy = skipped_codec + skipped_resolution + skipped_min_savings + skipped_max_savings + skipped_dry_run
         logger.log(f"Candidates found:     {len(cands)}")
         logger.log(f"Pre-filtered:         {prefiltered}")
         logger.log(f"Evaluated:            {evaluated}")
@@ -480,6 +547,7 @@ def run() -> int:
         logger.log(f"Skipped (codec):      {skipped_codec}")
         logger.log(f"Skipped (resolution): {skipped_resolution}")
         logger.log(f"Skipped (min savings): {skipped_min_savings}")
+        logger.log(f"Skipped (max savings): {skipped_max_savings}")
         logger.log(f"Skipped (dry run):    {skipped_dry_run}")
         logger.log(f"Ignored folders:      {len(ignored_folders)}")
         logger.log(f"Ignored files:        {ignored_files}")


### PR DESCRIPTION
Files changed:

src/chonk_reducer/config.py

src/chonk_reducer/runner.py

README.md

What changed
#42 — Free Space Guard

New env var: MIN_MEDIA_FREE_GB

At run start (after cleanup, before discovery), Chonk checks free space on the filesystem holding MEDIA_ROOT.

If free space is below threshold → abort run early (no file marking, no retries).

#43 — Max GB Per Run

New env var: MAX_GB_PER_RUN

Tracks cumulative saved_bytes for successful swaps in the current run.

If run reclaimed space reaches the limit → stop early (clean success exit).

#44 — Max Savings Percent

New env var: MAX_SAVINGS_PERCENT

Adds a symmetric “too aggressive” guard:

if savings % > MAX_SAVINGS_PERCENT → treat as Skipped (policy), delete encoded temp, record skip as skip_reason=max_savings.

YAML / Env updates to add
Recommended location: your .env

Put these near your existing run controls (same place as MIN_SAVINGS_PERCENT, etc.):

# Bundle C Guards
MIN_MEDIA_FREE_GB=50
MAX_GB_PER_RUN=40
MAX_SAVINGS_PERCENT=65

Why .env: both tv-transcoder and movie-transcoder inherit it automatically, and DSM scheduler overrides still work as expected.

If you don’t use .env, add under each service in compose.yaml

Under each service’s environment: block:

environment:
  - MIN_MEDIA_FREE_GB=50
  - MAX_GB_PER_RUN=40
  - MAX_SAVINGS_PERCENT=65


Closed #42  
Closed #43 
Closed #44