### PR TITLE
Release prep: v1.6.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Cory Koenig
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
                 Reduce the Chonk. Respect the Bits.
 ```
+Current Version: v1.6.0
 
 Chonk Reducer is a **policy-driven media size reduction system** built for NAS environments (Synology + Docker).
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,13 +10,13 @@ x-common-env: &common-env
   PYTHONDONTWRITEBYTECODE: 1               # avoid writing .pyc files entirely
 
   # ---- Run modes ----
-  DRY_RUN: "true"                          # if true, do everything except encode/swap (safe testing)
+  DRY_RUN: "false"                          # if true, do everything except encode/swap (safe testing)
   PREVIEW: "false"                         # if true, log “top candidates” only and exit (no per-file work)
   FAIL_FAST: "true"                        # if true, abort run on first hard failure
 
   # ---- Stats / Reporting ----
   STATS_ENABLED: "true"                    # append NDJSON rows to STATS_PATH for success/skip/fail events
-  APP_VERSION: "v1.4.0"                    # version stamp written into stats + startup banner
+  APP_VERSION: "v1.6.0"                    # version stamp written into stats + startup banner
   REPORTS_DIR: "/work/reports"             # where weekly-report writes its output text file(s)
   WEEKLY_REPORT_DAYS: "7"                  # how many days back weekly-report aggregates
   WEEKLY_STATS_PATHS: "/tv_shows/.chonkstats.ndjson,/movies/.chonkstats.ndjson"  # comma list of NDJSON inputs

--- a/src/chonk_reducer/__init__.py
+++ b/src/chonk_reducer/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.1.0"
+__version__ = "1.6.0"


### PR DESCRIPTION
Preparation for v1.6.0 release.

Changes:
- Bumped project version to v1.6.0
- Updated compose.yaml APP_VERSION
- Updated README version references
- Added MIT license

No runtime code changes.