### PR TITLE
Replace NDJSON Metrics with SQLite Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,9 @@ These are passed to the **container** via `compose.yaml` (`environment:`). Movie
 | `WORK_CLEANUP_HOURS` | `0` | Delete temp files under WORK_ROOT older than this many hours. |
 | `LOG_RETENTION_DAYS` | `30` | Delete old transcode logs under `/work/logs` older than this many days. |
 | `BAK_RETENTION_DAYS` | `60` | Delete old `*.bak.*` files under MEDIA_ROOT older than this many days. |
-| `STATS_ENABLED` | `True` | Write per-file NDJSON stats to STATS_PATH. |
-| `STATS_PATH` | `/movies/.chonkstats.ndjson` | Where NDJSON stats are written (container path). |
+| `STATS_ENABLED` | `True` | Write per-file metrics into SQLite (`runs` + `encodes`) at STATS_PATH. |
+| `STATS_PATH` | `/config/chonk.db` | SQLite database location for metrics and weekly reporting. |
+| `WEEKLY_STATS_PATHS` | `/config/chonk.db` | Comma-separated SQLite database paths for `weekly-report`. |
 | `WEEKLY_REPORT_DAYS` | `7` | Lookback window (days) for the weekly report command. |
 | `REPORT_RETENTION_DAYS` | `0` | Delete weekly report files older than this many days (0 disables). |
 | `LOCK_STALE_HOURS` | `12` | Consider a lock stale after this many hours. |
@@ -253,7 +254,7 @@ These are passed to the **container** via `compose.yaml` (`environment:`). Movie
 ### Notes
 
 - Values are read from env and parsed as bool/int/float where applicable.
-- `STATS_PATH` should live on the media volume if you want one stats file per library.
+- `STATS_PATH` now points to a SQLite DB (default `/config/chonk.db`). On first startup, legacy `.chonkstats.ndjson` in MEDIA_ROOT is auto-migrated and renamed to `.chonkstats.ndjson.migrated`.
 - `REPORT_RETENTION_DAYS` is applied by the `weekly-report` command to prune old `weekly_*.md` files.
 
 ---

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,11 +15,11 @@ x-common-env: &common-env
   FAIL_FAST: "true"                        # if true, abort run on first hard failure
 
   # ---- Stats / Reporting ----
-  STATS_ENABLED: "true"                    # append NDJSON rows to STATS_PATH for success/skip/fail events
-  APP_VERSION: "v1.6.0"                    # version stamp written into stats + startup banner
+  STATS_ENABLED: "true"                    # write SQLite rows to STATS_PATH for success/skip/fail events
+  APP_VERSION: "v1.6.1"                    # version stamp written into stats + startup banner
   REPORTS_DIR: "/work/reports"             # where weekly-report writes its output text file(s)
   WEEKLY_REPORT_DAYS: "7"                  # how many days back weekly-report aggregates
-  WEEKLY_STATS_PATHS: "/tv_shows/.chonkstats.ndjson,/movies/.chonkstats.ndjson"  # comma list of NDJSON inputs
+  WEEKLY_STATS_PATHS: "/config/chonk.db"  # comma list of SQLite DB inputs
   REPORT_RETENTION_DAYS: "30"              # delete weekly reports older than N days (weekly-report)
 
   # ---- Retries ----
@@ -94,7 +94,7 @@ services:
       # ---- Roots ----
       MEDIA_ROOT: /movies                    # media library root inside the container
       WORK_ROOT: /work                       # writable work root (logs/reports/tmp)
-      STATS_PATH: /movies/.chonkstats.ndjson # per-library NDJSON stats file
+      STATS_PATH: /config/chonk.db          # SQLite stats database
 
       # ---- Library-specific selection ----
       MIN_SIZE_GB: "17"                      # minimum file size to consider as a candidate
@@ -130,7 +130,7 @@ services:
       # ---- Roots ----
       MEDIA_ROOT: /tv_shows                  # media library root inside the container
       WORK_ROOT: /work                       # writable work root (logs/reports/tmp)
-      STATS_PATH: /tv_shows/.chonkstats.ndjson # per-library NDJSON stats file
+      STATS_PATH: /config/chonk.db          # SQLite stats database
 
       # ---- Library-specific selection ----
       MIN_SIZE_GB: "8"                       # minimum file size to consider as a candidate

--- a/src/chonk_reducer/__init__.py
+++ b/src/chonk_reducer/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "1.6.0"
+__version__ = "1.6.1"

--- a/src/chonk_reducer/cli.py
+++ b/src/chonk_reducer/cli.py
@@ -25,7 +25,7 @@ def main(argv: list[str] | None = None) -> int:
 
     sub.add_parser("run", help="Run transcoding pipeline (default)")
     sub.add_parser("healthcheck", help="Strict read-only healthcheck (no media processing)")
-    sub.add_parser("weekly-report", help="Generate weekly savings report from NDJSON stats")
+    sub.add_parser("weekly-report", help="Generate weekly savings report from SQLite stats")
 
     args = parser.parse_args(argv)
 

--- a/src/chonk_reducer/config.py
+++ b/src/chonk_reducer/config.py
@@ -111,9 +111,9 @@ class Config:
     skip_min_height: int = 0
     skip_resolution_tags: tuple[str, ...] = ()
 
-    # Stats (NDJSON)
+    # Stats (SQLite)
     stats_enabled: bool = False
-    stats_path: Path = Path("/work/.chonkstats.ndjson")
+    stats_path: Path = Path("/config/chonk.db")
     library: str = ""
     version: str = "unknown"
     encoder: str = "hevc_qsv"
@@ -132,7 +132,7 @@ def load_config() -> Config:
 
     # Stats defaults
     stats_enabled = _env_bool("STATS_ENABLED", True)
-    default_stats_path = media_root / ".chonkstats.ndjson"
+    default_stats_path = Path("/config/chonk.db")
     stats_path = Path(_env("STATS_PATH", str(default_stats_path)))
     library = _env("LIBRARY", "")
     encoder = _env("ENCODER", "hevc_qsv")

--- a/src/chonk_reducer/stats.py
+++ b/src/chonk_reducer/stats.py
@@ -1,33 +1,80 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import time
+from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, Iterable, List, Optional
 
 from .config import Config
 from .logging_utils import Logger
 
 
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS runs (
+    run_id TEXT PRIMARY KEY,
+    ts_start TEXT NOT NULL,
+    ts_end TEXT NOT NULL,
+    mode TEXT,
+    library TEXT,
+    version TEXT,
+    encoder TEXT,
+    quality INTEGER,
+    preset INTEGER,
+    success_count INTEGER NOT NULL DEFAULT 0,
+    failed_count INTEGER NOT NULL DEFAULT 0,
+    skipped_count INTEGER NOT NULL DEFAULT 0,
+    before_bytes INTEGER NOT NULL DEFAULT 0,
+    after_bytes INTEGER NOT NULL DEFAULT 0,
+    saved_bytes INTEGER NOT NULL DEFAULT 0,
+    duration_seconds REAL NOT NULL DEFAULT 0.0
+);
+
+CREATE TABLE IF NOT EXISTS encodes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    version TEXT,
+    library TEXT,
+    mode TEXT,
+    encoder TEXT,
+    quality INTEGER,
+    preset INTEGER,
+    status TEXT NOT NULL,
+    stage TEXT,
+    fail_stage TEXT,
+    skip_reason TEXT,
+    skip_detail TEXT,
+    path TEXT,
+    filename TEXT,
+    size_before_bytes INTEGER,
+    size_after_bytes INTEGER,
+    saved_bytes INTEGER,
+    saved_pct REAL,
+    codec_from TEXT,
+    codec_to TEXT,
+    duration_seconds REAL,
+    error_type TEXT,
+    error_msg TEXT,
+    encoded_path TEXT,
+    encoded_bytes INTEGER,
+    bak_path TEXT,
+    FOREIGN KEY(run_id) REFERENCES runs(run_id)
+);
+CREATE INDEX IF NOT EXISTS idx_encodes_ts ON encodes(ts);
+CREATE INDEX IF NOT EXISTS idx_encodes_library_ts ON encodes(library, ts);
+CREATE INDEX IF NOT EXISTS idx_encodes_status_ts ON encodes(status, ts);
+"""
+
+
 def _iso_ts() -> str:
-    # ISO-8601 without timezone (consistent with existing logs)
     return time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime())
 
 
 def _safe_str(e: Exception) -> str:
     s = str(e).replace("\n", " ").strip()
-    # keep it compact for Discord/logging/import
     return (s[:500] + "…") if len(s) > 500 else s
-
-
-def append_ndjson(path: Path, obj: dict[str, Any], logger: Logger) -> None:
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(obj, ensure_ascii=False, separators=(",", ":"))
-        with path.open("a", encoding="utf-8", newline="\n") as f:
-            f.write(line + "\n")
-    except Exception as e:
-        logger.log(f"WARN: stats append failed: {path} ({e})")
 
 
 def infer_library(cfg: Config) -> str:
@@ -54,6 +101,184 @@ def build_base(cfg: Config, run_id: str, mode: str) -> dict[str, Any]:
     }
 
 
+def _connect(db_path: Path) -> sqlite3.Connection:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL;")
+    conn.execute("PRAGMA foreign_keys=ON;")
+    conn.executescript(SCHEMA)
+    return conn
+
+
+def _legacy_stats_path(cfg: Config, db_path: Path) -> Path:
+    if db_path.suffix.lower() == ".ndjson":
+        return db_path
+    return Path(cfg.media_root) / ".chonkstats.ndjson"
+
+
+def _parse_ts(ts: str) -> Optional[datetime]:
+    try:
+        return datetime.fromisoformat(ts)
+    except Exception:
+        return None
+
+
+def _iter_ndjson(path: Path) -> Iterable[Dict[str, Any]]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except Exception:
+                    continue
+                if isinstance(row, dict):
+                    yield row
+    except Exception:
+        return
+
+
+def _update_run_summary(conn: sqlite3.Connection, run_id: str) -> None:
+    conn.execute(
+        """
+        UPDATE runs
+        SET
+            ts_start = COALESCE((SELECT MIN(ts) FROM encodes WHERE run_id = ?), ts_start),
+            ts_end = COALESCE((SELECT MAX(ts) FROM encodes WHERE run_id = ?), ts_end),
+            success_count = COALESCE((SELECT COUNT(*) FROM encodes WHERE run_id = ? AND status = 'success'), 0),
+            failed_count = COALESCE((SELECT COUNT(*) FROM encodes WHERE run_id = ? AND status = 'failed'), 0),
+            skipped_count = COALESCE((SELECT COUNT(*) FROM encodes WHERE run_id = ? AND status = 'skipped'), 0),
+            before_bytes = COALESCE((SELECT SUM(COALESCE(size_before_bytes, 0)) FROM encodes WHERE run_id = ? AND status = 'success'), 0),
+            after_bytes = COALESCE((SELECT SUM(COALESCE(size_after_bytes, 0)) FROM encodes WHERE run_id = ? AND status = 'success'), 0),
+            saved_bytes = COALESCE((SELECT SUM(COALESCE(saved_bytes, 0)) FROM encodes WHERE run_id = ? AND status = 'success'), 0),
+            duration_seconds = COALESCE((SELECT SUM(COALESCE(duration_seconds, 0.0)) FROM encodes WHERE run_id = ?), 0.0)
+        WHERE run_id = ?
+        """,
+        (run_id, run_id, run_id, run_id, run_id, run_id, run_id, run_id, run_id, run_id),
+    )
+
+
+def _insert_event(conn: sqlite3.Connection, obj: Dict[str, Any]) -> None:
+    run_id = str(obj.get("run_id") or "")
+    ts = str(obj.get("ts") or _iso_ts())
+    conn.execute(
+        """
+        INSERT INTO runs(run_id, ts_start, ts_end, mode, library, version, encoder, quality, preset)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(run_id) DO UPDATE SET
+            ts_start = MIN(runs.ts_start, excluded.ts_start),
+            ts_end = MAX(runs.ts_end, excluded.ts_end)
+        """,
+        (
+            run_id,
+            ts,
+            ts,
+            obj.get("mode"),
+            obj.get("library"),
+            obj.get("version"),
+            obj.get("encoder"),
+            obj.get("quality"),
+            obj.get("preset"),
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO encodes(
+            ts, run_id, version, library, mode, encoder, quality, preset,
+            status, stage, fail_stage, skip_reason, skip_detail,
+            path, filename, size_before_bytes, size_after_bytes,
+            saved_bytes, saved_pct, codec_from, codec_to, duration_seconds,
+            error_type, error_msg, encoded_path, encoded_bytes, bak_path
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            ts,
+            run_id,
+            obj.get("version"),
+            obj.get("library"),
+            obj.get("mode"),
+            obj.get("encoder"),
+            obj.get("quality"),
+            obj.get("preset"),
+            obj.get("status"),
+            obj.get("stage"),
+            obj.get("fail_stage"),
+            obj.get("skip_reason"),
+            obj.get("skip_detail"),
+            obj.get("path"),
+            obj.get("filename"),
+            obj.get("size_before_bytes"),
+            obj.get("size_after_bytes"),
+            obj.get("saved_bytes"),
+            obj.get("saved_pct"),
+            obj.get("codec_from"),
+            obj.get("codec_to"),
+            obj.get("duration_seconds"),
+            obj.get("error_type"),
+            obj.get("error_msg"),
+            obj.get("encoded_path"),
+            obj.get("encoded_bytes"),
+            obj.get("bak_path"),
+        ),
+    )
+    _update_run_summary(conn, run_id)
+
+
+def _migrate_ndjson_if_needed(cfg: Config, db_path: Path, logger: Logger) -> None:
+    migrated_marker = Path(str(_legacy_stats_path(cfg, db_path)) + ".migrated")
+    legacy = _legacy_stats_path(cfg, db_path)
+    if db_path.exists() or not legacy.exists() or migrated_marker.exists():
+        return
+
+    conn = _connect(db_path)
+    try:
+        with conn:
+            grouped: Dict[str, List[Dict[str, Any]]] = {}
+            unknown_index = 0
+            for row in _iter_ndjson(legacy):
+                run_id = str(row.get("run_id") or "").strip()
+                if not run_id:
+                    run_id = "legacy-unknown-%d" % unknown_index
+                    unknown_index += 1
+                row["run_id"] = run_id
+                grouped.setdefault(run_id, []).append(row)
+
+            for run_rows in grouped.values():
+                run_rows.sort(key=lambda r: str(r.get("ts") or ""))
+                for row in run_rows:
+                    _insert_event(conn, row)
+        legacy.rename(migrated_marker)
+        logger.log(f"Migrated NDJSON stats to SQLite: {legacy} -> {migrated_marker}")
+    except Exception as e:
+        logger.log(f"WARN: NDJSON migration failed safely: {legacy} ({e})")
+    finally:
+        conn.close()
+
+
+def ensure_database(cfg: Config, logger: Logger) -> Path:
+    db_path = Path(cfg.stats_path)
+    _migrate_ndjson_if_needed(cfg, db_path, logger)
+    conn = _connect(db_path)
+    conn.close()
+    return db_path
+
+
+def _record_event(cfg: Config, logger: Logger, obj: Dict[str, Any]) -> None:
+    if not getattr(cfg, "stats_enabled", False):
+        return
+    try:
+        db_path = ensure_database(cfg, logger)
+        conn = _connect(db_path)
+        with conn:
+            _insert_event(conn, obj)
+        conn.close()
+    except Exception as e:
+        logger.log(f"WARN: stats insert failed: {cfg.stats_path} ({e})")
+
+
 def record_success(
     cfg: Config,
     logger: Logger,
@@ -68,8 +293,6 @@ def record_success(
     duration_seconds: float,
     bak_path: Path | None = None,
 ) -> None:
-    if not getattr(cfg, "stats_enabled", False):
-        return
     saved = int(before_bytes) - int(after_bytes)
     pct = (saved / before_bytes) * 100.0 if before_bytes else 0.0
 
@@ -92,7 +315,7 @@ def record_success(
     if bak_path is not None:
         obj["bak_path"] = str(bak_path)
 
-    append_ndjson(Path(cfg.stats_path), obj, logger)
+    _record_event(cfg, logger, obj)
 
 
 def record_failure(
@@ -107,13 +330,10 @@ def record_failure(
     err: Exception,
     encoded_path: Path | None = None,
 ) -> None:
-    if not getattr(cfg, "stats_enabled", False):
-        return
-
     obj = build_base(cfg, run_id, mode)
     obj.update(
         {
-            "status":"failed",
+            "status": "failed",
             "stage": stage,
             "fail_stage": stage,
             "path": str(src),
@@ -132,7 +352,7 @@ def record_failure(
         except Exception:
             pass
 
-    append_ndjson(Path(cfg.stats_path), obj, logger)
+    _record_event(cfg, logger, obj)
 
 
 def record_skip(
@@ -146,13 +366,6 @@ def record_skip(
     codec_from: str | None = None,
     detail: str | None = None,
 ) -> None:
-    """Record a skipped file in NDJSON stats (policy/runtime skip, not pre-filter markers).
-
-    Note: We intentionally do not record marker/backup pre-filters to avoid bloating stats.
-    """
-    if not getattr(cfg, "stats_enabled", False):
-        return
-
     obj = build_base(cfg, run_id, mode)
     obj.update(
         {
@@ -168,7 +381,7 @@ def record_skip(
     if detail:
         obj["skip_detail"] = str(detail)[:500]
 
-    append_ndjson(Path(cfg.stats_path), obj, logger)
+    _record_event(cfg, logger, obj)
 
 
 def record_dry_run(
@@ -178,17 +391,44 @@ def record_dry_run(
     src: Path,
     before_bytes: int,
 ) -> None:
-    if not getattr(cfg, "stats_enabled", False):
-        return
     obj = build_base(cfg, run_id, "dry_run")
     obj.update(
         {
-            "status":"skipped",
-            "stage":"dry_run",
-            "skip_reason":"dry_run",
+            "status": "skipped",
+            "stage": "dry_run",
+            "skip_reason": "dry_run",
             "path": str(src),
             "filename": src.name,
             "size_before_bytes": int(before_bytes),
         }
     )
-    append_ndjson(Path(cfg.stats_path), obj, logger)
+    _record_event(cfg, logger, obj)
+
+
+def fetch_encodes_since(db_paths: List[Path], start: datetime) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    start_iso = start.strftime("%Y-%m-%dT%H:%M:%S")
+    for db_path in db_paths:
+        if not db_path.exists():
+            continue
+        try:
+            conn = _connect(db_path)
+            cur = conn.execute(
+                "SELECT * FROM encodes WHERE ts >= ? ORDER BY ts ASC",
+                (start_iso,),
+            )
+            rows.extend(dict(r) for r in cur.fetchall())
+            conn.close()
+        except Exception:
+            continue
+    return rows
+
+
+def fetch_run_summaries(db_path: Path) -> List[Dict[str, Any]]:
+    if not db_path.exists():
+        return []
+    conn = _connect(db_path)
+    cur = conn.execute("SELECT * FROM runs ORDER BY ts_start ASC")
+    out = [dict(r) for r in cur.fetchall()]
+    conn.close()
+    return out

--- a/src/chonk_reducer/weekly_report.py
+++ b/src/chonk_reducer/weekly_report.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import json
 import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Iterable, Optional
 
 from .discord_utils import send_discord_message, notify_weekly_enabled
 from .logging_utils import Logger
+from .stats import fetch_encodes_since
 
 
 def _env(name: str, default: str) -> str:
@@ -45,6 +44,8 @@ def _prune_old_reports(report_dir: Path, retention_days: int, logger: Logger) ->
                 continue
     if deleted:
         logger.log(f"Report retention: deleted {deleted} report(s) older than {retention_days} day(s)")
+
+
 def _fmt_gb(n_bytes: int) -> str:
     return f"{n_bytes / (1024**3):.2f}GB"
 
@@ -69,30 +70,6 @@ class Totals:
             self.saved_pct_avg = self._saved_pct_sum / self.success
 
 
-def _parse_ts(ts: str) -> Optional[datetime]:
-    try:
-        # NDJSON uses ISO without timezone, e.g. 2026-03-03T13:13:13
-        return datetime.fromisoformat(ts)
-    except Exception:
-        return None
-
-
-def _read_ndjson(path: Path) -> Iterable[dict]:
-    if not path.exists():
-        return []
-    rows = []
-    try:
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                rows.append(json.loads(line))
-            except Exception:
-                continue
-    except Exception:
-        return []
-    return rows
 
 
 def generate_weekly_report() -> int:
@@ -101,7 +78,7 @@ def generate_weekly_report() -> int:
     now = datetime.now()
     start = now - timedelta(days=days)
 
-    stats_paths_raw = _env("WEEKLY_STATS_PATHS", "/tv_shows/.chonkstats.ndjson,/movies/.chonkstats.ndjson")
+    stats_paths_raw = _env("WEEKLY_STATS_PATHS", "/config/chonk.db")
     stats_paths = [Path(p.strip()) for p in stats_paths_raw.split(",") if p.strip()]
 
     report_dir = Path(_env("REPORTS_DIR", "/work/reports"))
@@ -122,54 +99,52 @@ def generate_weekly_report() -> int:
     skip_reason_breakdown: dict[str, int] = {}
 
     total_rows = 0
-    for sp in stats_paths:
-        for row in _read_ndjson(sp):
-            total_rows += 1
-            ts = _parse_ts(str(row.get("ts", "")))
-            if not ts or ts < start:
-                continue
+    for row in fetch_encodes_since(stats_paths, start):
+        total_rows += 1
 
-            lib = str(row.get("library", "")).lower().strip() or "unknown"
-            if lib == "movie":
-                lib = "movies"
-            if lib not in by_lib:
-                by_lib[lib] = Totals()
+        lib = str(row.get("library", "")).lower().strip() or "unknown"
+        if lib == "movie":
+            lib = "movies"
+        if lib not in by_lib:
+            by_lib[lib] = Totals()
 
-            status = str(row.get("status", "")).lower().strip()
-            stage = str(row.get("fail_stage") or row.get("stage") or "").lower().strip()
+        status = str(row.get("status", "")).lower().strip()
+        stage = str(row.get("fail_stage") or row.get("stage") or "").lower().strip()
 
-            if status == "success":
-                b = int(row.get("size_before_bytes") or 0)
-                a = int(row.get("size_after_bytes") or 0)
-                s = int(row.get("saved_bytes") or max(b - a, 0))
-                pct = float(row.get("saved_pct") or 0.0)
+        if status == "success":
+            b = int(row.get("size_before_bytes") or 0)
+            a = int(row.get("size_after_bytes") or 0)
+            s = int(row.get("saved_bytes") or max(b - a, 0))
+            pct = float(row.get("saved_pct") or 0.0)
 
-                for t in (by_lib[lib], combined):
-                    t.success += 1
-                    t.before_bytes += b
-                    t.after_bytes += a
-                    t.saved_bytes += s
-                    t._saved_pct_sum += pct
+            for t in (by_lib[lib], combined):
+                t.success += 1
+                t.before_bytes += b
+                t.after_bytes += a
+                t.saved_bytes += s
+                t._saved_pct_sum += pct
 
-                top_saves.append({
+            top_saves.append(
+                {
                     "saved_bytes": s,
                     "saved_pct": pct,
                     "path": row.get("path") or row.get("filename") or "",
                     "library": lib,
-                })
-            elif status == "failed":
-                for t in (by_lib[lib], combined):
-                    t.failed += 1
-                if stage:
-                    fail_stage[stage] = fail_stage.get(stage, 0) + 1
-            elif status == "skipped":
-                for t in (by_lib[lib], combined):
-                    t.skipped += 1
-                sr = str(row.get("skip_reason") or "").lower().strip() or "unknown"
-                skip_reason_breakdown[sr] = skip_reason_breakdown.get(sr, 0) + 1
-            else:
-                for t in (by_lib[lib], combined):
-                    t.unknown += 1
+                }
+            )
+        elif status == "failed":
+            for t in (by_lib[lib], combined):
+                t.failed += 1
+            if stage:
+                fail_stage[stage] = fail_stage.get(stage, 0) + 1
+        elif status == "skipped":
+            for t in (by_lib[lib], combined):
+                t.skipped += 1
+            sr = str(row.get("skip_reason") or "").lower().strip() or "unknown"
+            skip_reason_breakdown[sr] = skip_reason_breakdown.get(sr, 0) + 1
+        else:
+            for t in (by_lib[lib], combined):
+                t.unknown += 1
 
     for t in list(by_lib.values()) + [combined]:
         t.finalize()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 from types import SimpleNamespace
 
-from chonk_reducer.stats import record_failure, record_skip, record_success
+from chonk_reducer.stats import (
+    ensure_database,
+    fetch_run_summaries,
+    record_failure,
+    record_skip,
+    record_success,
+)
 
 
 class StubLogger:
@@ -15,7 +22,7 @@ class StubLogger:
 def _cfg(tmp_path: Path):
     return SimpleNamespace(
         stats_enabled=True,
-        stats_path=tmp_path / "stats.ndjson",
+        stats_path=tmp_path / "chonk.db",
         version="test",
         media_root=tmp_path / "movies",
         library="movies",
@@ -25,7 +32,88 @@ def _cfg(tmp_path: Path):
     )
 
 
-def test_stats_record_success_and_saved_bytes(tmp_path):
+def _count_rows(db_path: Path, table: str) -> int:
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.execute(f"SELECT COUNT(*) FROM {table}")
+    val = int(cur.fetchone()[0])
+    conn.close()
+    return val
+
+
+def test_database_initialization_creates_schema_and_wal(tmp_path):
+    cfg = _cfg(tmp_path)
+    db_path = ensure_database(cfg, StubLogger())
+
+    assert db_path.exists()
+    conn = sqlite3.connect(str(db_path))
+    tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    mode = conn.execute("PRAGMA journal_mode;").fetchone()[0].lower()
+    conn.close()
+
+    assert "runs" in tables
+    assert "encodes" in tables
+    assert mode == "wal"
+
+
+def test_migration_from_ndjson(tmp_path):
+    cfg = _cfg(tmp_path)
+    legacy = cfg.media_root / ".chonkstats.ndjson"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    rows = [
+        {
+            "ts": "2026-01-01T00:00:01",
+            "run_id": "run-1",
+            "version": "test",
+            "library": "movies",
+            "mode": "live",
+            "encoder": "hevc_qsv",
+            "quality": 21,
+            "preset": 7,
+            "status": "success",
+            "stage": "swap",
+            "path": "/movies/a.mkv",
+            "filename": "a.mkv",
+            "size_before_bytes": 100,
+            "size_after_bytes": 60,
+            "saved_bytes": 40,
+            "saved_pct": 40.0,
+            "duration_seconds": 1.2,
+        },
+        {
+            "ts": "2026-01-01T00:00:03",
+            "run_id": "run-1",
+            "version": "test",
+            "library": "movies",
+            "mode": "live",
+            "encoder": "hevc_qsv",
+            "quality": 21,
+            "preset": 7,
+            "status": "failed",
+            "stage": "encode",
+            "fail_stage": "encode",
+            "path": "/movies/b.mkv",
+            "filename": "b.mkv",
+            "size_before_bytes": 200,
+            "duration_seconds": 0.3,
+            "error_type": "RuntimeError",
+            "error_msg": "boom",
+        },
+    ]
+    legacy.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+    ensure_database(cfg, StubLogger())
+
+    migrated = legacy.with_suffix(legacy.suffix + ".migrated")
+    assert migrated.exists()
+    assert not legacy.exists()
+    assert _count_rows(cfg.stats_path, "encodes") == 2
+    summaries = fetch_run_summaries(cfg.stats_path)
+    assert summaries[0]["run_id"] == "run-1"
+    assert summaries[0]["success_count"] == 1
+    assert summaries[0]["failed_count"] == 1
+
+
+def test_encode_insertion(tmp_path):
     cfg = _cfg(tmp_path)
     src = tmp_path / "movie.mkv"
     src.write_bytes(b"x")
@@ -44,12 +132,14 @@ def test_stats_record_success_and_saved_bytes(tmp_path):
         duration_seconds=1.2,
     )
 
-    row = json.loads(cfg.stats_path.read_text().splitlines()[0])
-    assert row["status"] == "success"
-    assert row["saved_bytes"] == 400
+    conn = sqlite3.connect(str(cfg.stats_path))
+    row = conn.execute("SELECT status, saved_bytes FROM encodes").fetchone()
+    conn.close()
+    assert row[0] == "success"
+    assert row[1] == 400
 
 
-def test_stats_record_skip_and_failure(tmp_path):
+def test_run_summaries(tmp_path):
     cfg = _cfg(tmp_path)
     src = tmp_path / "movie.mkv"
     src.write_bytes(b"x")
@@ -76,5 +166,9 @@ def test_stats_record_skip_and_failure(tmp_path):
         err=RuntimeError("boom"),
     )
 
-    rows = [json.loads(line) for line in cfg.stats_path.read_text().splitlines()]
-    assert [r["status"] for r in rows] == ["skipped", "failed"]
+    summaries = fetch_run_summaries(cfg.stats_path)
+    assert len(summaries) == 1
+    summary = summaries[0]
+    assert summary["run_id"] == "r2"
+    assert summary["skipped_count"] == 1
+    assert summary["failed_count"] == 1


### PR DESCRIPTION
### Motivation
- Move metrics storage from line-oriented NDJSON into a lightweight relational DB to enable richer queries and avoid NDJSON scaling issues.
- Preserve existing transcoding behavior while providing an automatic one-time migration from legacy NDJSON to the new DB format.

### Description
- Implemented SQLite-backed metrics storage in `src/chonk_reducer/stats.py` with DB initialization at `STATS_PATH` (default `/config/chonk.db`), WAL mode enabled, and schema creation for `runs` and `encodes` tables.
- Added one-time, safe NDJSON migration that parses `.chonkstats.ndjson` line-by-line, inserts events into `encodes`, rebuilds run rollups in `runs`, and renames the legacy file to `.chonkstats.ndjson.migrated` on success; migration runs only when DB is missing and legacy file exists.
- Replaced NDJSON append logic with DB inserts for `record_success`, `record_failure`, `record_skip`, and `record_dry_run`, and added helpers `fetch_encodes_since` and `fetch_run_summaries` for reporting.
- Updated `weekly-report` to read metrics from one or more SQLite DB paths (`WEEKLY_STATS_PATHS`), adjusted `Config` defaults to use `/config/chonk.db`, updated CLI help text, updated `README.md` and `compose.yaml` environment comments, and bumped package/compose app version to `1.6.1`.

### Testing
- Added unit tests exercising DB initialization/WAL, NDJSON migration, encode insertion, and run summary aggregation in `tests/test_stats.py` and ran the full test suite with `pytest -q` which passed.
- Verified `weekly-report` module compiles and integrates with new `fetch_encodes_since` helper via `python -m py_compile` and `pytest -q` (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa37c54048832b9aa514c2c5f6af59)