### PR TITLE
Fix per-library legacy NDJSON migration for shared SQLite stats DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
                 Reduce the Chonk. Respect the Bits.
 ```
 
-Current Version: v1.6.0
+Current Version: v1.6.2
 
 Chonk Reducer is a **policy-driven NAS media optimization pipeline** built for Synology + Docker environments.
 
@@ -198,6 +198,21 @@ git commit -m "Describe your change"
 
 ---
 
+
+## Legacy NDJSON Migration
+
+Chonk Reducer uses SQLite as the primary stats backend, but can still import legacy NDJSON stats files.
+
+- Migration runs during stats initialization on **every startup**.
+- Migration is evaluated per library path (`MEDIA_ROOT`), not by whether the shared DB already exists.
+- If `MEDIA_ROOT/.chonkstats.ndjson` exists, rows are streamed line-by-line into SQLite.
+- After a successful import, the file is renamed to `.chonkstats.ndjson.migrated`.
+- If `.chonkstats.ndjson.migrated` already exists, migration is skipped for that library.
+
+This allows multiple libraries that share `/config/chonk.db` to migrate independently without losing historical data.
+
+---
+
 ## Environment Variables
 
 These are passed to the **container** via `compose.yaml` (`environment:`). Movie and TV services should use the same keys.
@@ -254,7 +269,9 @@ These are passed to the **container** via `compose.yaml` (`environment:`). Movie
 ### Notes
 
 - Values are read from env and parsed as bool/int/float where applicable.
-- `STATS_PATH` now points to a SQLite DB (default `/config/chonk.db`). On first startup, legacy `.chonkstats.ndjson` in MEDIA_ROOT is auto-migrated and renamed to `.chonkstats.ndjson.migrated`.
+- `STATS_PATH` points to a shared SQLite DB (default `/config/chonk.db`) that can be used by multiple libraries (for example, movies and TV).
+- On every startup, each library checks its own `MEDIA_ROOT/.chonkstats.ndjson`. If present, records are imported into SQLite and the file is renamed to `.chonkstats.ndjson.migrated`.
+- Migration is idempotent: already-migrated files are skipped and duplicate legacy records are not inserted again.
 - `REPORT_RETENTION_DAYS` is applied by the `weekly-report` command to prune old `weekly_*.md` files.
 
 ---

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ x-common-env: &common-env
 
   # ---- Stats / Reporting ----
   STATS_ENABLED: "true"                    # write SQLite rows to STATS_PATH for success/skip/fail events
-  APP_VERSION: "v1.6.1"                    # version stamp written into stats + startup banner
+  APP_VERSION: "v1.6.2"                    # version stamp written into stats + startup banner
   REPORTS_DIR: "/work/reports"             # where weekly-report writes its output text file(s)
   WEEKLY_REPORT_DAYS: "7"                  # how many days back weekly-report aggregates
   WEEKLY_STATS_PATHS: "/config/chonk.db"  # comma list of SQLite DB inputs

--- a/src/chonk_reducer/__init__.py
+++ b/src/chonk_reducer/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "1.6.1"
+__version__ = "1.6.2"

--- a/src/chonk_reducer/stats.py
+++ b/src/chonk_reducer/stats.py
@@ -141,6 +141,37 @@ def _iter_ndjson(path: Path) -> Iterable[Dict[str, Any]]:
         return
 
 
+def _event_exists(conn: sqlite3.Connection, obj: Dict[str, Any]) -> bool:
+    row = conn.execute(
+        """
+        SELECT 1
+        FROM encodes
+        WHERE run_id = ?
+          AND ts = ?
+          AND status = ?
+          AND COALESCE(stage, '') = COALESCE(?, '')
+          AND COALESCE(path, '') = COALESCE(?, '')
+          AND COALESCE(filename, '') = COALESCE(?, '')
+          AND COALESCE(size_before_bytes, -1) = COALESCE(?, -1)
+          AND COALESCE(size_after_bytes, -1) = COALESCE(?, -1)
+          AND COALESCE(saved_bytes, -1) = COALESCE(?, -1)
+        LIMIT 1
+        """,
+        (
+            str(obj.get("run_id") or ""),
+            str(obj.get("ts") or ""),
+            str(obj.get("status") or ""),
+            obj.get("stage"),
+            obj.get("path"),
+            obj.get("filename"),
+            obj.get("size_before_bytes"),
+            obj.get("size_after_bytes"),
+            obj.get("saved_bytes"),
+        ),
+    ).fetchone()
+    return row is not None
+
+
 def _update_run_summary(conn: sqlite3.Connection, run_id: str) -> None:
     conn.execute(
         """
@@ -228,15 +259,16 @@ def _insert_event(conn: sqlite3.Connection, obj: Dict[str, Any]) -> None:
 
 
 def _migrate_ndjson_if_needed(cfg: Config, db_path: Path, logger: Logger) -> None:
-    migrated_marker = Path(str(_legacy_stats_path(cfg, db_path)) + ".migrated")
     legacy = _legacy_stats_path(cfg, db_path)
-    if db_path.exists() or not legacy.exists() or migrated_marker.exists():
+    migrated_marker = Path(str(legacy) + ".migrated")
+    if not legacy.exists() or migrated_marker.exists():
         return
 
+    logger.log(f"Migrating legacy stats file: {legacy}")
     conn = _connect(db_path)
     try:
+        imported = 0
         with conn:
-            grouped: Dict[str, List[Dict[str, Any]]] = {}
             unknown_index = 0
             for row in _iter_ndjson(legacy):
                 run_id = str(row.get("run_id") or "").strip()
@@ -244,14 +276,12 @@ def _migrate_ndjson_if_needed(cfg: Config, db_path: Path, logger: Logger) -> Non
                     run_id = "legacy-unknown-%d" % unknown_index
                     unknown_index += 1
                 row["run_id"] = run_id
-                grouped.setdefault(run_id, []).append(row)
-
-            for run_rows in grouped.values():
-                run_rows.sort(key=lambda r: str(r.get("ts") or ""))
-                for row in run_rows:
+                if not _event_exists(conn, row):
                     _insert_event(conn, row)
+                    imported += 1
+        logger.log(f"Imported {imported} legacy records")
         legacy.rename(migrated_marker)
-        logger.log(f"Migrated NDJSON stats to SQLite: {legacy} -> {migrated_marker}")
+        logger.log(f"Renamed file to {migrated_marker.name}")
     except Exception as e:
         logger.log(f"WARN: NDJSON migration failed safely: {legacy} ({e})")
     finally:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -15,8 +15,11 @@ from chonk_reducer.stats import (
 
 
 class StubLogger:
+    def __init__(self) -> None:
+        self.messages = []
+
     def log(self, msg: str) -> None:
-        pass
+        self.messages.append(msg)
 
 
 def _cfg(tmp_path: Path):
@@ -30,6 +33,32 @@ def _cfg(tmp_path: Path):
         qsv_quality=21,
         qsv_preset=7,
     )
+
+
+
+
+def _write_legacy_event(path: Path, *, run_id: str = "run-legacy") -> None:
+    row = {
+        "ts": "2026-01-01T00:00:01",
+        "run_id": run_id,
+        "version": "test",
+        "library": "movies",
+        "mode": "live",
+        "encoder": "hevc_qsv",
+        "quality": 21,
+        "preset": 7,
+        "status": "success",
+        "stage": "swap",
+        "path": "/movies/a.mkv",
+        "filename": "a.mkv",
+        "size_before_bytes": 100,
+        "size_after_bytes": 60,
+        "saved_bytes": 40,
+        "saved_pct": 40.0,
+        "duration_seconds": 1.2,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(row) + "\n", encoding="utf-8")
 
 
 def _count_rows(db_path: Path, table: str) -> int:
@@ -111,6 +140,94 @@ def test_migration_from_ndjson(tmp_path):
     assert summaries[0]["run_id"] == "run-1"
     assert summaries[0]["success_count"] == 1
     assert summaries[0]["failed_count"] == 1
+
+
+
+
+def test_migration_runs_when_db_exists(tmp_path):
+    cfg = _cfg(tmp_path)
+    logger = StubLogger()
+    ensure_database(cfg, logger)
+
+    legacy = cfg.media_root / ".chonkstats.ndjson"
+    _write_legacy_event(legacy, run_id="run-db-exists")
+
+    ensure_database(cfg, logger)
+
+    migrated = legacy.with_suffix(legacy.suffix + ".migrated")
+    assert migrated.exists()
+    assert _count_rows(cfg.stats_path, "encodes") == 1
+
+
+def test_migration_is_idempotent_and_renames_file(tmp_path):
+    cfg = _cfg(tmp_path)
+    logger = StubLogger()
+    legacy = cfg.media_root / ".chonkstats.ndjson"
+    _write_legacy_event(legacy, run_id="run-idempotent")
+
+    ensure_database(cfg, logger)
+    first_count = _count_rows(cfg.stats_path, "encodes")
+
+    ensure_database(cfg, logger)
+
+    migrated = legacy.with_suffix(legacy.suffix + ".migrated")
+    assert migrated.exists()
+    assert not legacy.exists()
+    assert first_count == 1
+    assert _count_rows(cfg.stats_path, "encodes") == 1
+
+
+def test_migration_skips_duplicate_records(tmp_path):
+    cfg = _cfg(tmp_path)
+    logger = StubLogger()
+    ensure_database(cfg, logger)
+
+    src = tmp_path / "movie.mkv"
+    src.write_bytes(b"x")
+    record_success(
+        cfg,
+        logger,
+        run_id="run-dup",
+        mode="live",
+        stage="swap",
+        src=src,
+        before_bytes=100,
+        after_bytes=60,
+        codec_from="h264",
+        codec_to="hevc",
+        duration_seconds=1.2,
+    )
+
+    conn = sqlite3.connect(str(cfg.stats_path))
+    ts = conn.execute("SELECT ts FROM encodes WHERE run_id = ?", ("run-dup",)).fetchone()[0]
+    conn.close()
+
+    legacy = cfg.media_root / ".chonkstats.ndjson"
+    row = {
+        "ts": ts,
+        "run_id": "run-dup",
+        "version": "test",
+        "library": "movies",
+        "mode": "live",
+        "encoder": "hevc_qsv",
+        "quality": 21,
+        "preset": 7,
+        "status": "success",
+        "stage": "swap",
+        "path": str(src),
+        "filename": src.name,
+        "size_before_bytes": 100,
+        "size_after_bytes": 60,
+        "saved_bytes": 40,
+        "saved_pct": 40.0,
+        "duration_seconds": 1.2,
+    }
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+    ensure_database(cfg, logger)
+
+    assert _count_rows(cfg.stats_path, "encodes") == 1
 
 
 def test_encode_insertion(tmp_path):


### PR DESCRIPTION
### Motivation

- The legacy `.chonkstats.ndjson` migration previously only ran when the SQLite DB did not exist, causing libraries that shared the same DB (e.g., movies and TV) to lose historical records when one library created the DB first. 
- Migration must run per-library (per `MEDIA_ROOT/.chonkstats.ndjson`) on every startup and remain idempotent and safe so it never crashes the transcoder.

### Description

- Updated `_migrate_ndjson_if_needed` to detect and import `MEDIA_ROOT/.chonkstats.ndjson` regardless of whether the DB exists, and to rename the file to `.chonkstats.ndjson.migrated` after successful import; migration is skipped if the `.migrated` marker already exists. 
- Added `_event_exists` to detect and skip duplicate events before inserting, preventing duplicate inserts when multiple libraries share `/config/chonk.db`. 
- Kept streaming NDJSON processing via `_iter_ndjson`, preserved tolerance for malformed lines, and added logging messages for start, imported record count, and rename completion (`logger.log`).
- Bumped patch version to `1.6.2`, updated `compose.yaml` `APP_VERSION`, added README section `Legacy NDJSON Migration`, and added unit tests exercising per-library migration, rename/idempotency, and duplicate suppression.

Files modified: `src/chonk_reducer/stats.py`, `tests/test_stats.py`, `README.md`, `src/chonk_reducer/__init__.py`, `compose.yaml`.

### Testing

- Added unit tests covering: migration when the DB already exists, file rename and idempotency across repeated `ensure_database` calls, and duplicate record suppression; tests were added/updated in `tests/test_stats.py`.
- Ran the test suite with `pytest -q`, which completed successfully: `20 passed in 0.27s`.
- No tests failed and the migration changes were exercised by the new tests for the described scenarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa6261fdc8832bad3f3b12f6eb53d7)