### PR TITLE
Run legacy stats migration at startup before discovery

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ x-common-env: &common-env
 
   # ---- Stats / Reporting ----
   STATS_ENABLED: "true"                    # write SQLite rows to STATS_PATH for success/skip/fail events
-  APP_VERSION: "v1.6.2"                    # version stamp written into stats + startup banner
+  APP_VERSION: "v1.6.3"                    # version stamp written into stats + startup banner
   REPORTS_DIR: "/work/reports"             # where weekly-report writes its output text file(s)
   WEEKLY_REPORT_DAYS: "7"                  # how many days back weekly-report aggregates
   WEEKLY_STATS_PATHS: "/config/chonk.db"  # comma list of SQLite DB inputs

--- a/src/chonk_reducer/__init__.py
+++ b/src/chonk_reducer/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "1.6.2"
+__version__ = "1.6.3"

--- a/src/chonk_reducer/runner.py
+++ b/src/chonk_reducer/runner.py
@@ -16,7 +16,7 @@ from .swap import swap_in
 from .validation import validate_post_encode
 from .ffmpeg_utils import probe_video_stream
 from .skip_policy import evaluate_skip
-from .stats import record_success, record_failure, record_dry_run, record_skip
+from .stats import ensure_database, record_success, record_failure, record_dry_run, record_skip
 from . import __version__ as PKG_VERSION
 
 
@@ -130,6 +130,9 @@ def run() -> int:
         logger.log(f"RUN DURATION: {_fmt_hms(run_duration)}")
         logger.log("===== END =====")
         return 1
+
+    if getattr(cfg, "stats_enabled", False):
+        ensure_database(cfg, logger)
 
     # Global pause (no cleanup/discovery/processing)
     pause_file = cfg.media_root / ".chonkpause"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import sqlite3
 import types
 from pathlib import Path
 
@@ -165,3 +167,50 @@ def test_run_exits_when_free_space_too_low(tmp_path, monkeypatch):
     rc = runner.run()
 
     assert rc == 2
+
+
+def test_run_migrates_legacy_stats_with_zero_candidates(tmp_path, monkeypatch):
+    cfg = _base_cfg(tmp_path, stats_enabled=True, stats_path=tmp_path / "chonk.db")
+    legacy = cfg.media_root / ".chonkstats.ndjson"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy_row = {
+        "ts": "2026-01-01T00:00:01",
+        "run_id": "run-zero-cands",
+        "version": "test",
+        "library": "movies",
+        "mode": "live",
+        "encoder": "hevc_qsv",
+        "quality": 21,
+        "preset": 7,
+        "status": "success",
+        "stage": "swap",
+        "path": "/movies/a.mkv",
+        "filename": "a.mkv",
+        "size_before_bytes": 100,
+        "size_after_bytes": 60,
+        "saved_bytes": 40,
+        "saved_pct": 40.0,
+        "duration_seconds": 1.2,
+    }
+    legacy.write_text(json.dumps(legacy_row) + "\n", encoding="utf-8")
+
+    monkeypatch.setattr(runner, "load_config", lambda: cfg)
+    monkeypatch.setattr(runner, "acquire_lock", lambda *a, **k: True)
+    monkeypatch.setattr(runner, "release_lock", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "cleanup_work_dir", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "cleanup_media_temp", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "cleanup_logs", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "cleanup_baks", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "gather_candidates", lambda *a, **k: ([], {}))
+
+    rc = runner.run()
+
+    assert rc == 0
+    migrated = legacy.with_suffix(legacy.suffix + ".migrated")
+    assert migrated.exists()
+    assert not legacy.exists()
+
+    conn = sqlite3.connect(str(cfg.stats_path))
+    count = conn.execute("SELECT COUNT(*) FROM encodes").fetchone()[0]
+    conn.close()
+    assert count == 1


### PR DESCRIPTION
### Motivation
- Fix a bug where legacy NDJSON migration did not run if a run produced zero candidate events, because migration was only triggered during per-event stats initialization.

### Description
- Call `ensure_database(cfg, logger)` from `runner.run()` immediately after config validation so SQLite bootstrap and NDJSON migration run once at startup and before discovery/pause checks.
- Preserve idempotent migration behavior and legacy-file rename to `.chonkstats.ndjson.migrated` by reusing existing `ensure_database` logic in `stats.py` and adding no migration logic changes there.
- Added regression test `test_run_migrates_legacy_stats_with_zero_candidates` to `tests/test_runner.py` that creates a legacy `.chonkstats.ndjson`, runs `runner.run()` with zero candidates, and verifies import and rename.
- Bumped patch version to `1.6.3` and updated `compose.yaml` app version; files changed: `src/chonk_reducer/runner.py`, `tests/test_runner.py`, `src/chonk_reducer/__init__.py`, and `compose.yaml`.

### Testing
- Ran `pytest -q` and all tests passed: `21 passed in 0.26s` (the new regression test is included and passed).
- Verified the new test confirms the legacy NDJSON file is imported into SQLite and renamed to `.migrated` when there are zero discovery candidates.
- No other automated checks were modified and existing tests remain green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa67516bdc832b98204abb8886fca8)