### PR TITLE
Handle docker image lookup failures in wrapper and bump v1.7.1

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ x-common-env: &common-env
 
   # ---- Stats / Reporting ----
   STATS_ENABLED: "true"                    # write SQLite rows to STATS_PATH for success/skip/fail events
-  APP_VERSION: "v1.7.0"                    # version stamp written into stats + startup banner
+  APP_VERSION: "v1.7.1"                    # version stamp written into stats + startup banner
   REPORTS_DIR: "/work/reports"             # where weekly-report writes its output text file(s)
   WEEKLY_REPORT_DAYS: "7"                  # how many days back weekly-report aggregates
   WEEKLY_STATS_PATHS: "/config/chonk.db"  # comma list of SQLite DB inputs

--- a/scripts/chonkreducer_task.sh
+++ b/scripts/chonkreducer_task.sh
@@ -126,7 +126,14 @@ REBUILD_NO_CACHE="${REBUILD_NO_CACHE:-true}"
 if [ "$REBUILD_IMAGE" = "true" ]; then
   SHOULD_BUILD="$REPO_CHANGED"
   if [ "$SHOULD_BUILD" != "true" ]; then
-    EXISTING_IMAGE_ID="$($DOCKER compose -f "$COMPOSE" images -q "$SERVICE" 2>>"$TASK_LOG" || true)"
+    set +e
+    EXISTING_IMAGE_ID="$($DOCKER compose -f "$COMPOSE" images -q "$SERVICE" 2>>"$TASK_LOG")"
+    IMAGE_LOOKUP_RC=$?
+    set -e
+    if [ $IMAGE_LOOKUP_RC -ne 0 ]; then
+      log "[build] image lookup failed for $SERVICE (continuing with rebuild)"
+      EXISTING_IMAGE_ID=""
+    fi
     if [ -z "$EXISTING_IMAGE_ID" ]; then
       SHOULD_BUILD="true"
       log "[build] no local image found for $SERVICE — building container"

--- a/src/chonk_reducer/__init__.py
+++ b/src/chonk_reducer/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "1.7.0"
+__version__ = "1.7.1"

--- a/tests/test_task_wrapper.py
+++ b/tests/test_task_wrapper.py
@@ -49,6 +49,9 @@ def _write_fake_tools(tmp_path: Path) -> tuple[Path, Path]:
     fake_docker.write_text(
         "#!/bin/sh\n"
         "echo \"$*\" >>\"$DOCKER_CALLS\"\n"
+        "if [ \"${FAKE_IMAGES_FAIL:-0}\" = \"1\" ] && echo \"$*\" | grep -q \"images -q\"; then\n"
+        "  exit 1\n"
+        "fi\n"
         "case \"$*\" in\n"
         "  *\"images -q\"*)\n"
         "    [ -n \"${FAKE_IMAGE_ID:-}\" ] && echo \"$FAKE_IMAGE_ID\"\n"
@@ -70,7 +73,14 @@ def _write_fake_tools(tmp_path: Path) -> tuple[Path, Path]:
     return fake_docker, bin_dir
 
 
-def _run_wrapper(project: Path, script_path: Path, service: str, *, fake_image_id: str = "img-123") -> tuple[int, str]:
+def _run_wrapper(
+    project: Path,
+    script_path: Path,
+    service: str,
+    *,
+    fake_image_id: str = "img-123",
+    fake_images_fail: str = "0",
+) -> tuple[int, str]:
     docker_calls = project / "docker_calls.log"
     python_calls = project / "python_calls.log"
     compose = project / "compose.yaml"
@@ -90,6 +100,7 @@ def _run_wrapper(project: Path, script_path: Path, service: str, *, fake_image_i
             "REBUILD_IMAGE": "true",
             "REBUILD_NO_CACHE": "false",
             "FAKE_IMAGE_ID": fake_image_id,
+            "FAKE_IMAGES_FAIL": fake_images_fail,
             "PATH": f"{bin_dir}:{env['PATH']}",
         }
     )
@@ -134,3 +145,16 @@ def test_task_builds_when_image_missing_even_without_repo_updates(tmp_path: Path
     assert "[git] repository up to date — skipping pull" in log_text
     assert "[build] no local image found for svc-fresh — building container" in log_text
     assert "[build] rebuilding image for service: svc-fresh" in log_text
+
+
+def test_task_builds_when_image_lookup_fails_even_without_repo_updates(tmp_path: Path) -> None:
+    project = _setup_git_clone(tmp_path)
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "chonkreducer_task.sh"
+
+    rc, log_text = _run_wrapper(project, script_path, "svc-image-lookup-fail", fake_images_fail="1")
+
+    assert rc == 0
+    assert "[git] repository up to date — skipping pull" in log_text
+    assert "[build] image lookup failed for svc-image-lookup-fail (continuing with rebuild)" in log_text
+    assert "[build] no local image found for svc-image-lookup-fail — building container" in log_text
+    assert "[build] rebuilding image for service: svc-image-lookup-fail" in log_text


### PR DESCRIPTION
### Motivation
- Wrapper runs were exiting with code 1 when `docker compose images -q` returned a non-zero status under `set -e`, breaking the skip-rebuild/no-change logic and causing wrapper tests to fail.  
- The intent is to preserve the optimization (skip pytest/build when repo unchanged and image exists) while ensuring missing-image and lookup-failure paths still trigger a rebuild and return exit code 0.  

### Description
- Hardened `scripts/chonkreducer_task.sh` image-existence lookup by temporarily disabling `errexit` (`set +e`), capturing the `docker` exit code, logging a lookup failure, and treating lookup failures as “no image” so the build proceeds.  
- Extended `tests/test_task_wrapper.py` with a `FAKE_IMAGES_FAIL` simulation and added `test_task_builds_when_image_lookup_fails_even_without_repo_updates` to assert the wrapper logs the lookup failure, rebuilds, and exits 0.  
- Bumped the patch version from `1.7.0` to `1.7.1` in `src/chonk_reducer/__init__.py` and `compose.yaml`.  
- Files changed: `scripts/chonkreducer_task.sh`, `tests/test_task_wrapper.py`, `src/chonk_reducer/__init__.py`, and `compose.yaml`.  

### Testing
- Ran the wrapper unit tests `tests/test_task_wrapper.py` and the full test suite with `pytest -q`, and all tests passed locally.  
- Test summary: `25 passed` (including the new image-lookup-failure regression test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa78082ba4832b8ea07c2af96c3afd)