### PR TITLE
Fix Docker Compose image skip logic in NAS task wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,9 @@ The task wrapper now checks for remote Git updates before rebuilding containers:
 1. `git fetch --all --prune`
 2. compare local `HEAD` with upstream remote head
 3. if commits changed: pull latest, run `pytest -q`, rebuild image
-4. if unchanged: skip pull/test/build and reuse existing image
-5. always run `docker compose run --rm <service>`
+4. if unchanged: resolve the Compose-built image name and skip pull/test/build when that local image exists
+5. if unchanged and image is missing: rebuild image, then run
+6. always run `docker compose run --rm <service>`
 
 This reduces NAS CPU usage by avoiding unnecessary Docker builds while still rebuilding whenever code changes are detected.
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ x-common-env: &common-env
 
   # ---- Stats / Reporting ----
   STATS_ENABLED: "true"                    # write SQLite rows to STATS_PATH for success/skip/fail events
-  APP_VERSION: "v1.7.1"                    # version stamp written into stats + startup banner
+  APP_VERSION: "v1.7.2"                    # version stamp written into stats + startup banner
   REPORTS_DIR: "/work/reports"             # where weekly-report writes its output text file(s)
   WEEKLY_REPORT_DAYS: "7"                  # how many days back weekly-report aggregates
   WEEKLY_STATS_PATHS: "/config/chonk.db"  # comma list of SQLite DB inputs

--- a/scripts/chonkreducer_task.sh
+++ b/scripts/chonkreducer_task.sh
@@ -123,18 +123,42 @@ fi
 # --- REBUILD IMAGE (only when code changed, or image missing) ---
 REBUILD_IMAGE="${REBUILD_IMAGE:-true}"
 REBUILD_NO_CACHE="${REBUILD_NO_CACHE:-true}"
+
+compose_service_image_exists() {
+  service="$1"
+
+  set +e
+  service_image_name="$($DOCKER compose -f "$COMPOSE" config --images "$service" 2>>"$TASK_LOG")"
+  image_name_rc=$?
+  set -e
+
+  if [ $image_name_rc -ne 0 ]; then
+    return 1
+  fi
+
+  service_image_name="$(printf '%s\n' "$service_image_name" | awk 'NF {print; exit}')"
+  if [ -z "$service_image_name" ]; then
+    return 1
+  fi
+
+  set +e
+  "$DOCKER" image inspect "$service_image_name" >/dev/null 2>>"$TASK_LOG"
+  image_inspect_rc=$?
+  set -e
+
+  if [ $image_inspect_rc -eq 0 ]; then
+    return 0
+  fi
+
+  return 1
+}
+
 if [ "$REBUILD_IMAGE" = "true" ]; then
   SHOULD_BUILD="$REPO_CHANGED"
   if [ "$SHOULD_BUILD" != "true" ]; then
-    set +e
-    EXISTING_IMAGE_ID="$($DOCKER compose -f "$COMPOSE" images -q "$SERVICE" 2>>"$TASK_LOG")"
-    IMAGE_LOOKUP_RC=$?
-    set -e
-    if [ $IMAGE_LOOKUP_RC -ne 0 ]; then
-      log "[build] image lookup failed for $SERVICE (continuing with rebuild)"
-      EXISTING_IMAGE_ID=""
-    fi
-    if [ -z "$EXISTING_IMAGE_ID" ]; then
+    if compose_service_image_exists "$SERVICE"; then
+      log "[build] repository up to date and local image exists — skipping container rebuild"
+    else
       SHOULD_BUILD="true"
       log "[build] no local image found for $SERVICE — building container"
     fi
@@ -148,7 +172,9 @@ if [ "$REBUILD_IMAGE" = "true" ]; then
     log "[build] rebuilding image for service: $SERVICE ($BUILD_ARGS)"
     "$DOCKER" compose -f "$COMPOSE" build $BUILD_ARGS "$SERVICE" >>"$TASK_LOG" 2>&1 || { log "[build] docker compose build failed; aborting"; exit 1; }
   else
-    log "[build] repository up to date — skipping container rebuild"
+    if [ "$REPO_CHANGED" = "true" ]; then
+      log "[build] repository up to date — skipping container rebuild"
+    fi
   fi
 fi
 

--- a/src/chonk_reducer/__init__.py
+++ b/src/chonk_reducer/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "1.7.1"
+__version__ = "1.7.2"

--- a/tests/test_task_wrapper.py
+++ b/tests/test_task_wrapper.py
@@ -49,12 +49,19 @@ def _write_fake_tools(tmp_path: Path) -> tuple[Path, Path]:
     fake_docker.write_text(
         "#!/bin/sh\n"
         "echo \"$*\" >>\"$DOCKER_CALLS\"\n"
-        "if [ \"${FAKE_IMAGES_FAIL:-0}\" = \"1\" ] && echo \"$*\" | grep -q \"images -q\"; then\n"
+        "if [ \"${FAKE_IMAGE_LOOKUP_FAIL:-0}\" = \"1\" ] && echo \"$*\" | grep -q \"config --images\"; then\n"
         "  exit 1\n"
         "fi\n"
+        "if [ \"${FAKE_IMAGE_LOOKUP_EMPTY:-0}\" = \"1\" ] && echo \"$*\" | grep -q \"config --images\"; then\n"
+        "  exit 0\n"
+        "fi\n"
         "case \"$*\" in\n"
-        "  *\"images -q\"*)\n"
-        "    [ -n \"${FAKE_IMAGE_ID:-}\" ] && echo \"$FAKE_IMAGE_ID\"\n"
+        "  *\"config --images\"*)\n"
+        "    echo \"${FAKE_SERVICE_IMAGE_NAME:-}\"\n"
+        "    ;;\n"
+        "  *\"image inspect\"*)\n"
+        "    [ \"${FAKE_IMAGE_INSPECT_FOUND:-1}\" = \"1\" ] && exit 0\n"
+        "    exit 1\n"
         "    ;;\n"
         "esac\n",
         encoding="utf-8",
@@ -78,8 +85,10 @@ def _run_wrapper(
     script_path: Path,
     service: str,
     *,
-    fake_image_id: str = "img-123",
-    fake_images_fail: str = "0",
+    fake_service_image_name: str = "nas-transcoder-test-service",
+    fake_image_inspect_found: str = "1",
+    fake_image_lookup_fail: str = "0",
+    fake_image_lookup_empty: str = "0",
 ) -> tuple[int, str]:
     docker_calls = project / "docker_calls.log"
     python_calls = project / "python_calls.log"
@@ -99,8 +108,10 @@ def _run_wrapper(
             "RUN_PYTEST": "true",
             "REBUILD_IMAGE": "true",
             "REBUILD_NO_CACHE": "false",
-            "FAKE_IMAGE_ID": fake_image_id,
-            "FAKE_IMAGES_FAIL": fake_images_fail,
+            "FAKE_SERVICE_IMAGE_NAME": fake_service_image_name,
+            "FAKE_IMAGE_INSPECT_FOUND": fake_image_inspect_found,
+            "FAKE_IMAGE_LOOKUP_FAIL": fake_image_lookup_fail,
+            "FAKE_IMAGE_LOOKUP_EMPTY": fake_image_lookup_empty,
             "PATH": f"{bin_dir}:{env['PATH']}",
         }
     )
@@ -120,7 +131,7 @@ def test_task_skips_build_and_pytest_when_repo_unchanged(tmp_path: Path) -> None
     assert rc == 0
     assert "[git] repository up to date — skipping pull" in log_text
     assert "[test] repository unchanged — skipping pytest" in log_text
-    assert "[build] repository up to date — skipping container rebuild" in log_text
+    assert "[build] repository up to date and local image exists — skipping container rebuild" in log_text
 
 
 def test_task_pulls_and_rebuilds_when_updates_detected(tmp_path: Path) -> None:
@@ -139,7 +150,7 @@ def test_task_builds_when_image_missing_even_without_repo_updates(tmp_path: Path
     project = _setup_git_clone(tmp_path)
     script_path = Path(__file__).resolve().parents[1] / "scripts" / "chonkreducer_task.sh"
 
-    rc, log_text = _run_wrapper(project, script_path, "svc-fresh", fake_image_id="")
+    rc, log_text = _run_wrapper(project, script_path, "svc-fresh", fake_image_inspect_found="0")
 
     assert rc == 0
     assert "[git] repository up to date — skipping pull" in log_text
@@ -151,10 +162,21 @@ def test_task_builds_when_image_lookup_fails_even_without_repo_updates(tmp_path:
     project = _setup_git_clone(tmp_path)
     script_path = Path(__file__).resolve().parents[1] / "scripts" / "chonkreducer_task.sh"
 
-    rc, log_text = _run_wrapper(project, script_path, "svc-image-lookup-fail", fake_images_fail="1")
+    rc, log_text = _run_wrapper(project, script_path, "svc-image-lookup-fail", fake_image_lookup_fail="1")
 
     assert rc == 0
     assert "[git] repository up to date — skipping pull" in log_text
-    assert "[build] image lookup failed for svc-image-lookup-fail (continuing with rebuild)" in log_text
     assert "[build] no local image found for svc-image-lookup-fail — building container" in log_text
     assert "[build] rebuilding image for service: svc-image-lookup-fail" in log_text
+
+
+def test_task_builds_when_image_name_lookup_returns_empty(tmp_path: Path) -> None:
+    project = _setup_git_clone(tmp_path)
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "chonkreducer_task.sh"
+
+    rc, log_text = _run_wrapper(project, script_path, "svc-image-name-empty", fake_image_lookup_empty="1")
+
+    assert rc == 0
+    assert "[git] repository up to date — skipping pull" in log_text
+    assert "[build] no local image found for svc-image-name-empty — building container" in log_text
+    assert "[build] rebuilding image for service: svc-image-name-empty" in log_text


### PR DESCRIPTION
### Motivation
- The NAS task wrapper was rebuilding compose-built services every run because the local image existence check used the wrong lookup and missed Compose-produced image names. 
- The goal is to avoid unnecessary `docker compose build` when the repo is unchanged and a compose-built image already exists, while still rebuilding when the repo changed or the image is missing.

### Description
- Added `compose_service_image_exists()` to `scripts/chonkreducer_task.sh` which resolves the service image via `docker compose config --images <service>` and verifies presence with `docker image inspect <resolved-image>`.
- Replaced the previous image-id lookup with the new compose-aware check and updated the rebuild decision and logging to skip rebuild when unchanged and the local image exists, and to rebuild when missing or lookup fails.
- Updated `tests/test_task_wrapper.py` to mock `docker compose config --images` and `docker image inspect`, added a test for empty image-name lookup, and adjusted existing tests to assert the new messages/behavior.
- Bumped the patch version from `1.7.1` to `1.7.2` in `src/chonk_reducer/__init__.py` and `compose.yaml`, and updated README task-wrapper workflow notes to reflect Compose-aware detection.

### Testing
- Ran the full test suite with `pytest -q` and all tests passed: `26 passed`.
- New and updated unit tests validate unchanged+existing image skip, unchanged+missing image build, updated-repo pull/test/build behavior, and lookup-failure fallbacks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa7c02279c832b810de579982e9427)