### PR TITLE
Fix NAS wrapper to skip pytest only for validated commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,14 +148,19 @@ Example DSM task using wrapper:
 
 ### NAS task workflow optimization
 
-The task wrapper now checks for remote Git updates before rebuilding containers:
+The task wrapper now checks for remote Git updates before rebuilding containers and persists per-service test validation state:
 
 1. `git fetch --all --prune`
 2. compare local `HEAD` with upstream remote head
-3. if commits changed: pull latest, run `pytest -q`, rebuild image
-4. if unchanged: resolve the Compose-built image name and skip pull/test/build when that local image exists
-5. if unchanged and image is missing: rebuild image, then run
-6. always run `docker compose run --rm <service>`
+3. if commits changed: pull latest, run `pytest -q`, record successful commit SHA, rebuild image
+4. if unchanged: only skip `pytest` when current `HEAD` already matches the last successfully tested SHA for that service
+5. if unchanged and image exists: skip rebuild
+6. if unchanged and image is missing: build image (but only after commit validation rules above are satisfied)
+7. always run `docker compose run --rm <service>`
+
+Wrapper validation state is saved under `STATE_ROOT` (default: `<project>/.task_state`) using files like:
+
+- `<service>.last_tested_sha`
 
 This reduces NAS CPU usage by avoiding unnecessary Docker builds while still rebuilding whenever code changes are detected.
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ x-common-env: &common-env
 
   # ---- Stats / Reporting ----
   STATS_ENABLED: "true"                    # write SQLite rows to STATS_PATH for success/skip/fail events
-  APP_VERSION: "v1.7.2"                    # version stamp written into stats + startup banner
+  APP_VERSION: "v1.7.3"                    # version stamp written into stats + startup banner
   REPORTS_DIR: "/work/reports"             # where weekly-report writes its output text file(s)
   WEEKLY_REPORT_DAYS: "7"                  # how many days back weekly-report aggregates
   WEEKLY_STATS_PATHS: "/config/chonk.db"  # comma list of SQLite DB inputs

--- a/scripts/chonkreducer_task.sh
+++ b/scripts/chonkreducer_task.sh
@@ -24,6 +24,10 @@ DISCORD_USER_ID="${DISCORD_USER_ID:-}"
 LOG_DIR="$PROJ_DIR/logs"
 mkdir -p "$LOG_DIR"
 
+# Where to store wrapper state (host)
+STATE_ROOT="${STATE_ROOT:-$PROJ_DIR/.task_state}"
+mkdir -p "$STATE_ROOT"
+
 STAMP="$(date +%Y%m%d-%H%M%S)"
 TASK_LOG="$LOG_DIR/${SERVICE}_${STAMP}.task.log"
 
@@ -107,17 +111,49 @@ else
   log "[git] git not available or repo not initialized; skipping update check"
 fi
 
-# --- QUICK SAFETY CHECK (pytest, only after repo changes) ---
+# --- QUICK SAFETY CHECK (pytest required unless current commit already validated) ---
 RUN_PYTEST="${RUN_PYTEST:-true}"
-if [ "$RUN_PYTEST" = "true" ] && [ "$REPO_CHANGED" = "true" ]; then
-  if command -v python3 >/dev/null 2>&1; then
-    log "[test] running pytest..."
-    PYTHONPATH=src python3 -m pytest -q >>"$TASK_LOG" 2>&1 || { log "[test] pytest failed; aborting"; exit 1; }
+CURRENT_HEAD=""
+if command -v git >/dev/null 2>&1 && [ -d ".git" ]; then
+  CURRENT_HEAD="$(git rev-parse HEAD 2>/dev/null || true)"
+fi
+
+LAST_TESTED_FILE="$STATE_ROOT/${SERVICE}.last_tested_sha"
+LAST_TESTED_SHA=""
+if [ -f "$LAST_TESTED_FILE" ]; then
+  LAST_TESTED_SHA="$(sed -n '1p' "$LAST_TESTED_FILE" 2>/dev/null | tr -d '[:space:]')"
+fi
+
+if [ "$RUN_PYTEST" = "true" ]; then
+  NEEDS_PYTEST="false"
+  if [ "$REPO_CHANGED" = "true" ]; then
+    log "[test] current commit not yet validated — running pytest"
+    NEEDS_PYTEST="true"
+  elif [ -n "$CURRENT_HEAD" ] && [ "$CURRENT_HEAD" = "$LAST_TESTED_SHA" ]; then
+    log "[test] current commit already validated — skipping pytest"
   else
-    log "[test] python3 not found; skipping pytest"
+    log "[test] current commit not yet validated — running pytest"
+    NEEDS_PYTEST="true"
   fi
-elif [ "$RUN_PYTEST" = "true" ]; then
-  log "[test] repository unchanged — skipping pytest"
+
+  if [ "$NEEDS_PYTEST" = "true" ]; then
+    if command -v python3 >/dev/null 2>&1; then
+      PYTHONPATH=src python3 -m pytest -q >>"$TASK_LOG" 2>&1 || {
+        SHORT_SHA="$(printf '%.7s' "$CURRENT_HEAD")"
+        [ -z "$SHORT_SHA" ] && SHORT_SHA="unknown"
+        log "[test] pytest failed for commit $SHORT_SHA — aborting"
+        exit 1
+      }
+      if [ -n "$CURRENT_HEAD" ]; then
+        printf '%s\n' "$CURRENT_HEAD" >"$LAST_TESTED_FILE"
+        log "[test] pytest passed for commit $(printf '%.7s' "$CURRENT_HEAD")"
+      else
+        log "[test] pytest passed"
+      fi
+    else
+      log "[test] python3 not found; skipping pytest"
+    fi
+  fi
 fi
 
 # --- REBUILD IMAGE (only when code changed, or image missing) ---

--- a/src/chonk_reducer/__init__.py
+++ b/src/chonk_reducer/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "1.7.2"
+__version__ = "1.7.3"

--- a/tests/test_task_wrapper.py
+++ b/tests/test_task_wrapper.py
@@ -72,6 +72,9 @@ def _write_fake_tools(tmp_path: Path) -> tuple[Path, Path]:
     fake_python.write_text(
         "#!/bin/sh\n"
         "echo \"$*\" >>\"$PYTHON_CALLS\"\n"
+        "if [ \"${FAKE_PYTEST_FAIL:-0}\" = \"1\" ]; then\n"
+        "  exit 1\n"
+        "fi\n"
         "exit 0\n",
         encoding="utf-8",
     )
@@ -89,7 +92,8 @@ def _run_wrapper(
     fake_image_inspect_found: str = "1",
     fake_image_lookup_fail: str = "0",
     fake_image_lookup_empty: str = "0",
-) -> tuple[int, str]:
+    fake_pytest_fail: str = "0",
+) -> tuple[int, str, str, str, Path]:
     docker_calls = project / "docker_calls.log"
     python_calls = project / "python_calls.log"
     compose = project / "compose.yaml"
@@ -112,6 +116,7 @@ def _run_wrapper(
             "FAKE_IMAGE_INSPECT_FOUND": fake_image_inspect_found,
             "FAKE_IMAGE_LOOKUP_FAIL": fake_image_lookup_fail,
             "FAKE_IMAGE_LOOKUP_EMPTY": fake_image_lookup_empty,
+            "FAKE_PYTEST_FAIL": fake_pytest_fail,
             "PATH": f"{bin_dir}:{env['PATH']}",
         }
     )
@@ -119,62 +124,117 @@ def _run_wrapper(
     run = subprocess.run(["/bin/sh", str(script_path), service], cwd=project, env=env, capture_output=True, text=True)
     task_logs = sorted((project / "logs").glob(f"{service}_*.task.log"))
     assert task_logs, "task log should be created"
-    return run.returncode, task_logs[-1].read_text(encoding="utf-8")
+    docker_text = docker_calls.read_text(encoding="utf-8") if docker_calls.exists() else ""
+    python_text = python_calls.read_text(encoding="utf-8") if python_calls.exists() else ""
+    return run.returncode, task_logs[-1].read_text(encoding="utf-8"), docker_text, python_text, project / ".task_state"
 
 
-def test_task_skips_build_and_pytest_when_repo_unchanged(tmp_path: Path) -> None:
+def test_repo_unchanged_and_commit_previously_validated_skips_pytest(tmp_path: Path) -> None:
     project = _setup_git_clone(tmp_path)
     script_path = Path(__file__).resolve().parents[1] / "scripts" / "chonkreducer_task.sh"
+    head_sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=project, check=True, capture_output=True, text=True).stdout.strip()
+    state_dir = project / ".task_state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "svc-unchanged.last_tested_sha").write_text(f"{head_sha}\n", encoding="utf-8")
 
-    rc, log_text = _run_wrapper(project, script_path, "svc-unchanged")
+    rc, log_text, docker_calls, python_calls, _ = _run_wrapper(project, script_path, "svc-unchanged")
 
     assert rc == 0
     assert "[git] repository up to date — skipping pull" in log_text
-    assert "[test] repository unchanged — skipping pytest" in log_text
+    assert "[test] current commit already validated — skipping pytest" in log_text
+    assert python_calls == ""
     assert "[build] repository up to date and local image exists — skipping container rebuild" in log_text
+    assert "compose -f" in docker_calls
 
 
-def test_task_pulls_and_rebuilds_when_updates_detected(tmp_path: Path) -> None:
+def test_repo_changed_pytest_passes_records_commit_and_builds(tmp_path: Path) -> None:
     project = _setup_git_clone(tmp_path, with_remote_update=True)
     script_path = Path(__file__).resolve().parents[1] / "scripts" / "chonkreducer_task.sh"
 
-    rc, log_text = _run_wrapper(project, script_path, "svc-updated")
+    rc, log_text, _, _, state_root = _run_wrapper(project, script_path, "svc-updated")
+    head_sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=project, check=True, capture_output=True, text=True).stdout.strip()
 
     assert rc == 0
     assert "[git] updates detected — pulling latest changes" in log_text
-    assert "[test] running pytest..." in log_text
+    assert "[test] current commit not yet validated — running pytest" in log_text
+    assert f"[test] pytest passed for commit {head_sha[:7]}" in log_text
     assert "[build] rebuilding image for service: svc-updated" in log_text
+    assert (state_root / "svc-updated.last_tested_sha").read_text(encoding="utf-8").strip() == head_sha
 
 
-def test_task_builds_when_image_missing_even_without_repo_updates(tmp_path: Path) -> None:
+def test_repo_changed_pytest_fails_aborts_and_does_not_record_or_build(tmp_path: Path) -> None:
+    project = _setup_git_clone(tmp_path, with_remote_update=True)
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "chonkreducer_task.sh"
+
+    rc, log_text, docker_calls, python_calls, state_root = _run_wrapper(
+        project,
+        script_path,
+        "svc-fail",
+        fake_pytest_fail="1",
+    )
+    head_sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=project, check=True, capture_output=True, text=True).stdout.strip()
+
+    assert rc != 0
+    assert "[test] current commit not yet validated — running pytest" in log_text
+    assert f"[test] pytest failed for commit {head_sha[:7]} — aborting" in log_text
+    assert "-m pytest -q" in python_calls
+    assert "compose -f" not in docker_calls or " build " not in docker_calls
+    assert " run --rm " not in docker_calls
+    assert not (state_root / "svc-fail.last_tested_sha").exists()
+
+
+def test_repo_unchanged_commit_not_validated_runs_pytest(tmp_path: Path) -> None:
     project = _setup_git_clone(tmp_path)
     script_path = Path(__file__).resolve().parents[1] / "scripts" / "chonkreducer_task.sh"
 
-    rc, log_text = _run_wrapper(project, script_path, "svc-fresh", fake_image_inspect_found="0")
+    rc, log_text, _, python_calls, state_root = _run_wrapper(project, script_path, "svc-unvalidated")
+    head_sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=project, check=True, capture_output=True, text=True).stdout.strip()
+
+    assert rc == 0
+    assert "[test] current commit not yet validated — running pytest" in log_text
+    assert "-m pytest -q" in python_calls
+    assert (state_root / "svc-unvalidated.last_tested_sha").read_text(encoding="utf-8").strip() == head_sha
+
+
+def test_repo_unchanged_image_missing_commit_validated_builds_without_pytest(tmp_path: Path) -> None:
+    project = _setup_git_clone(tmp_path)
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "chonkreducer_task.sh"
+    head_sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=project, check=True, capture_output=True, text=True).stdout.strip()
+    state_dir = project / ".task_state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "svc-fresh.last_tested_sha").write_text(f"{head_sha}\n", encoding="utf-8")
+
+    rc, log_text, _, python_calls, _ = _run_wrapper(project, script_path, "svc-fresh", fake_image_inspect_found="0")
 
     assert rc == 0
     assert "[git] repository up to date — skipping pull" in log_text
+    assert "[test] current commit already validated — skipping pytest" in log_text
+    assert python_calls == ""
     assert "[build] no local image found for svc-fresh — building container" in log_text
     assert "[build] rebuilding image for service: svc-fresh" in log_text
 
 
-def test_task_builds_when_image_lookup_fails_even_without_repo_updates(tmp_path: Path) -> None:
+def test_repo_unchanged_image_missing_commit_not_validated_runs_pytest_then_build(tmp_path: Path) -> None:
     project = _setup_git_clone(tmp_path)
     script_path = Path(__file__).resolve().parents[1] / "scripts" / "chonkreducer_task.sh"
 
-    rc, log_text = _run_wrapper(project, script_path, "svc-image-lookup-fail", fake_image_lookup_fail="1")
+    rc, log_text, _, python_calls, state_root = _run_wrapper(project, script_path, "svc-image-lookup-fail", fake_image_lookup_fail="1")
+    head_sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=project, check=True, capture_output=True, text=True).stdout.strip()
 
     assert rc == 0
     assert "[git] repository up to date — skipping pull" in log_text
+    assert "[test] current commit not yet validated — running pytest" in log_text
+    assert "-m pytest -q" in python_calls
     assert "[build] no local image found for svc-image-lookup-fail — building container" in log_text
     assert "[build] rebuilding image for service: svc-image-lookup-fail" in log_text
+    assert (state_root / "svc-image-lookup-fail.last_tested_sha").read_text(encoding="utf-8").strip() == head_sha
 
 
 def test_task_builds_when_image_name_lookup_returns_empty(tmp_path: Path) -> None:
     project = _setup_git_clone(tmp_path)
     script_path = Path(__file__).resolve().parents[1] / "scripts" / "chonkreducer_task.sh"
 
-    rc, log_text = _run_wrapper(project, script_path, "svc-image-name-empty", fake_image_lookup_empty="1")
+    rc, log_text, _, _, _ = _run_wrapper(project, script_path, "svc-image-name-empty", fake_image_lookup_empty="1")
 
     assert rc == 0
     assert "[git] repository up to date — skipping pull" in log_text


### PR DESCRIPTION
### Motivation
- The wrapper previously skipped `pytest` based only on repository change detection, allowing an unvalidated commit to be accepted if a prior run failed; this made runs unsafe.
- The goal is to ensure `pytest` is only skipped when the exact `HEAD` commit has been previously validated successfully for that service.

### Description
- Add per-service validation state under `STATE_ROOT` (default: `<project>/.task_state`) with files named `<service>.last_tested_sha` to record the last commit SHA that passed `pytest` (`scripts/chonkreducer_task.sh`).
- Change skip logic so `pytest` is run when the repo changed or when current `HEAD` does not match the recorded tested SHA, and write the current `HEAD` to the state file only after `pytest` passes; failed tests abort immediately without recording state, building, or running the container (`scripts/chonkreducer_task.sh`).
- Preserve existing image-build behavior while enforcing commit validation: if image is missing, the wrapper will only skip `pytest` when the commit is validated; otherwise it runs `pytest` then builds (`scripts/chonkreducer_task.sh`).
- Update unit tests in `tests/test_task_wrapper.py` to cover changed/pass, changed/fail, unchanged+validated (skip), unchanged+unvalidated (run), image-missing+validated (build without pytest), and image-missing+unvalidated (pytest then build).
- Update documentation to describe the new workflow and `STATE_ROOT` usage (`README.md`).
- Bump patch version from `1.7.2` to `1.7.3` in `src/chonk_reducer/__init__.py` and `compose.yaml`.

### Testing
- Added/updated tests in `tests/test_task_wrapper.py` exercising all required scenarios; ran the full suite with `pytest -q` and all tests passed.
- Test run: `pytest -q` => `28 passed in ~2.9s`.
- The wrapper now emits explicit logs for test decisions, for example: `[git] updates detected`, `[test] current commit not yet validated — running pytest`, `[test] pytest passed for commit 82e87ad`, `[test] current commit already validated — skipping pytest`, and `[test] pytest failed for commit 82e87ad — aborting`.

Files changed: `scripts/chonkreducer_task.sh`, `tests/test_task_wrapper.py`, `README.md`, `src/chonk_reducer/__init__.py`, `compose.yaml`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa8007ac30832b863ef014ee7f72ab)